### PR TITLE
feature: 🌮 Add taxonomies to Pages

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -58,3 +58,21 @@ if ( file_exists( UCSC_DIR . '/lib/functions/admin-menus.php' ) ) {
 if ( file_exists( UCSC_DIR . '/lib/functions/scripts.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/scripts.php';
 }
+
+// General functions.
+
+/**
+ * Add Taxonomies to Pages
+ *
+ * Adds taxonomies to pages in addition to posts
+ * @since 1.4.0
+ * @author UC Santa Cruz
+ * @license GNU General Public License 2.0+
+ */
+
+add_action( 'init', 'ucsc_custom_functionality_add_taxonomies_to_pages' );
+
+function ucsc_custom_functionality_add_taxonomies_to_pages() {
+	register_taxonomy_for_object_type( 'post_tag', 'page' );
+	register_taxonomy_for_object_type( 'category', 'page' );
+}


### PR DESCRIPTION
This PR adds taxonomies to Pages in addition to Posts. The taxonomies are the default that WordPress provides, Categories and Tags.

**Discussion**
Codewise, I considered adding another include file, `taxonomies.php`; however, considering that we can create custom taxonomies via a plugin CampusPress provides, any new taxonomies would be created in the interface, leaving the include file with only a single function. 

For this reason, I enabled the taxonomies in the primary `plugin.php` file below the list of includes.

The Question I have is whether _both_ Categories and Tags are necessary for Pages. 

The code in this PR does the following:

**Before:** 
![page-taxonomy-before](https://github.com/ucsc/ucsc-custom-functionality/assets/1000543/3ec44fbf-65d4-4a79-80e1-161ef1d1d252)

**After 1:**
![page-taxonomies-after-1](https://github.com/ucsc/ucsc-custom-functionality/assets/1000543/7fbe2339-b05d-4cfd-bce5-243d8b5ca814)

**After 2:**
![page-taxonomies-after-2](https://github.com/ucsc/ucsc-custom-functionality/assets/1000543/23011660-e93d-4e7a-a8e3-8819fdcf6d63)

