### PR TITLE
fix: 🐛 Remove xmlrpc link from wp_head since we've disabled the functionality in WordPress

### DIFF
--- a/lib/functions/scripts/disable-xmlrpc.php
+++ b/lib/functions/scripts/disable-xmlrpc.php
@@ -15,3 +15,7 @@ add_filter(
 	},
 	PHP_INT_MAX
 );
+
+// Removes the link from the <head>.
+// Avoids a11y issue with broken link
+remove_action('wp_head', 'rsd_link');


### PR DESCRIPTION
Siteimprove was reporting the broken link