### PR TITLE
feat: 🎉 Add plugin admin settings page under the Settings Menu in the Dashboard

### DIFF
--- a/lib/css/admin-settings.css
+++ b/lib/css/admin-settings.css
@@ -1,5 +1,4 @@
 .cf-admin-settings-page {
-    font-family: roboto;
     line-height: 1.5;
 }
 .cf-admin-settings-page p, .cf-admin-settings-page ul {

--- a/lib/css/admin-settings.css
+++ b/lib/css/admin-settings.css
@@ -1,0 +1,17 @@
+.cf-admin-settings-page {
+    font-family: roboto;
+    line-height: 1.5;
+}
+.cf-admin-settings-page p, .cf-admin-settings-page ul {
+    font-size: 1rem;
+}
+.cf-admin-settings-page ul {
+    display: block;
+    list-style-type: disc;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+    unicode-bidi: isolate;
+}

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -38,6 +38,7 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 		<h1><?php echo $plugin_data['Name']; ?></h1>
 		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
 		<p><?php echo $plugin_data['Description']; ?></p>
+		<hr>
 		<h3>Features added by this plugin:</h3>
 		<ul>
 			<li><strong>Google Analytics 4</strong> script to site footer</li>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -41,13 +41,12 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 		<hr>
 		<h3>Features added by this plugin:</h3>
 		<ul>
-			<li><strong>Google Analytics 4</strong> script to site footer</li>
-			<li><strong>Site Improve</strong> script to site footer</li>
+			<li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
 			<li><strong>Custom Shortcodes:</strong>
 				<ul>
-					<li><code>[site-search]</code>: Returns the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
-					<li><code>[copyright]</code>: Returns copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>
-					<li><code>[last-modified]</code>: Returns the <strong><i>Last modified</i></strong> date in the site footer</li>
+					<li><code>[site-search]</code>: Displays the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
+					<li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>
+					<li><code>[last-modified]</code>: Displays the <i>last modified</i> date of a page</li>
 				</ul>
 			</li>
 		</ul>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -34,19 +34,19 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 	function ucsc_render_plugin_settings_page() {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
 		?>
-        <div class="custom-functionality-settings">
+		<div class="wrap cf-admin-settings-page">
 		<h1><?php echo $plugin_data['Name']; ?></h1>
 		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
 		<p><?php echo $plugin_data['Description']; ?></p>
 		<h3>Features added by this plugin:</h3>
 		<ul>
-			<li>Google Analytics 4</li>
-			<li>Site Improve</li>
-			<li>Custom Shortcodes:
+			<li><strong>Google Analytics 4 script</strong></li>
+			<li><strong>Site Improve script</strong></li>
+			<li><strong>Custom Shortcodes:</strong>
 				<ul>
 					<li><code>[site-search]</code>: Returns the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
 					<li><code>[copyright]</code>: Returns copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>
-					<li><code>[last-modified]</code>: Returns the "Last modified" date in the site footer</li>
+					<li><code>[last-modified]</code>: Returns the <strong><i>Last modified</i></strong> date in the site footer</li>
 				</ul>
 			</li>
 		</ul>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Add Plugin settings and info page
+ *
+ * This file contains functions to add a settings/info page below WordPress Settings menu
+ *
+ * @package      ucsc
+ * @since        1.7.0
+ * @link         https://github.com/ucsc/ucsc-custom-functionality.git
+ * @author       UC Santa Cruz
+ * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/** Register new menu and page */
+
+if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
+	function ucsc_add_settings_page() {
+		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality Info', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
+	}
+}
+add_action( 'admin_menu', 'ucsc_add_settings_page' );
+
+
+/** 
+ * HTML output of Settings page 
+ *
+ * note: This page typically displays a form for displaying any settings options. 
+ * It is not needed at this point
+ *
+ */
+
+if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
+	function ucsc_render_plugin_settings_page() {
+		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
+		?><h1>UCSC Custom Functionality Plugin</h1>
+		<h2>Version: <?php echo $plugin_data['Version']; ?></h2><?php
+	}
+}
+
+
+

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 			<li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
 			<li><strong>Shortcodes:</strong>
 				<ul>
-					<li><code>[site-search]</code>: Displays the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
+					<li><code>[site-search]</code>: Inserts the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
 					<li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>
 					<li><code>[last-modified]</code>: Displays the <i>last modified</i> date of a page</li>
 				</ul>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -15,7 +15,7 @@
 
 if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
 	function ucsc_add_settings_page() {
-		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality Info', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
+		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality Settings', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
 	}
 }
 add_action( 'admin_menu', 'ucsc_add_settings_page' );
@@ -25,7 +25,8 @@ add_action( 'admin_menu', 'ucsc_add_settings_page' );
  * HTML output of Settings page 
  *
  * note: This page typically displays a form for displaying any settings options. 
- * It is not needed at this point
+ * It is not needed at this point.
+ * https://developer.wordpress.org/plugins/settings/custom-settings-page/
  *
  */
 
@@ -34,8 +35,8 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
 		?>
 		<h1>UCSC Custom Functionality Plugin</h1>
-		<h2>Version: <?php echo $plugin_data['Version']; ?></h2>
-		<p>Custom functionality for UCSC WordPress Websites.</p>
+		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
+		<p><?php echo $plugin_data['Description']; ?></p>
 		<?php
 	}
 }

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 		<h3>Features added by this plugin:</h3>
 		<ul>
 			<li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
-			<li><strong>Custom Shortcodes:</strong>
+			<li><strong>Shortcodes:</strong>
 				<ul>
 					<li><code>[site-search]</code>: Displays the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
 					<li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -34,9 +34,23 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 	function ucsc_render_plugin_settings_page() {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
 		?>
+        <div class="custom-functionality-settings">
 		<h1><?php echo $plugin_data['Name']; ?></h1>
 		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
 		<p><?php echo $plugin_data['Description']; ?></p>
+		<h3>Features added by this plugin:</h3>
+		<ul>
+			<li>Google Analytics 4</li>
+			<li>Site Improve</li>
+			<li>Custom Shortcodes:
+				<ul>
+					<li><code>[site-search]</code>: Returns the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
+					<li><code>[copyright]</code>: Returns copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>
+					<li><code>[last-modified]</code>: Returns the "Last modified" date in the site footer</li>
+				</ul>
+			</li>
+		</ul>
+		</div>
 		<?php
 	}
 }

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -15,7 +15,7 @@
 
 if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
 	function ucsc_add_settings_page() {
-		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality Settings', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
+		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
 	}
 }
 add_action( 'admin_menu', 'ucsc_add_settings_page' );

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -40,8 +40,8 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 		<p><?php echo $plugin_data['Description']; ?></p>
 		<h3>Features added by this plugin:</h3>
 		<ul>
-			<li><strong>Google Analytics 4 script</strong></li>
-			<li><strong>Site Improve script</strong></li>
+			<li><strong>Google Analytics 4</strong> script to site footer</li>
+			<li><strong>Site Improve</strong> script to site footer</li>
 			<li><strong>Custom Shortcodes:</strong>
 				<ul>
 					<li><code>[site-search]</code>: Returns the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -32,8 +32,11 @@ add_action( 'admin_menu', 'ucsc_add_settings_page' );
 if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 	function ucsc_render_plugin_settings_page() {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
-		?><h1>UCSC Custom Functionality Plugin</h1>
-		<h2>Version: <?php echo $plugin_data['Version']; ?></h2><?php
+		?>
+		<h1>UCSC Custom Functionality Plugin</h1>
+		<h2>Version: <?php echo $plugin_data['Version']; ?></h2>
+		<p>Custom functionality for UCSC WordPress Websites.</p>
+		<?php
 	}
 }
 

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
 	function ucsc_render_plugin_settings_page() {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
 		?>
-		<h1>UCSC Custom Functionality Plugin</h1>
+		<h1><?php echo $plugin_data['Name']; ?></h1>
 		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
 		<p><?php echo $plugin_data['Description']; ?></p>
 		<?php

--- a/plugin.php
+++ b/plugin.php
@@ -67,24 +67,3 @@ if ( file_exists( UCSC_DIR . '/lib/functions/settings.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/settings.php';
 }
 
-/** 
- * Add link to Settings page from Plugins
- */
-add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'ucsc_custom_functionality_plugin_action_links' );
-
-function ucsc_custom_functionality_plugin_action_links( $links ) {
-	// Build and escape the URL.
-	$url = esc_url( add_query_arg(
-		'page',
-		'ucsc-custom-functionality-settings',
-		get_admin_url() . 'options-general.php'
-	) );
-	// Create the link.
-	$settings_link = "<a href='$url'>" . __( 'Settings' ) . '</a>';
-	// Adds the link to the end of the array.
-	array_push(
-		$links,
-		$settings_link
-	);
-	return $links;
-}

--- a/plugin.php
+++ b/plugin.php
@@ -80,7 +80,7 @@ function ucsc_custom_functionality_plugin_action_links( $links ) {
 		get_admin_url() . 'options-general.php'
 	) );
 	// Create the link.
-	$settings_link = "<a href='$url'>" . __( 'Info' ) . '</a>';
+	$settings_link = "<a href='$url'>" . __( 'Settings' ) . '</a>';
 	// Adds the link to the end of the array.
 	array_push(
 		$links,

--- a/plugin.php
+++ b/plugin.php
@@ -61,3 +61,30 @@ if ( file_exists( UCSC_DIR . '/lib/functions/admin-menus.php' ) ) {
 if ( file_exists( UCSC_DIR . '/lib/functions/scripts.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/scripts.php';
 }
+
+// Settings.
+if ( file_exists( UCSC_DIR . '/lib/functions/settings.php' ) ) {
+	include_once UCSC_DIR . '/lib/functions/settings.php';
+}
+
+/** 
+ * Add link to Settings page from Plugins
+ */
+add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'ucsc_custom_functionality_plugin_action_links' );
+
+function ucsc_custom_functionality_plugin_action_links( $links ) {
+	// Build and escape the URL.
+	$url = esc_url( add_query_arg(
+		'page',
+		'ucsc-custom-functionality-settings',
+		get_admin_url() . 'options-general.php'
+	) );
+	// Create the link.
+	$settings_link = "<a href='$url'>" . __( 'Info' ) . '</a>';
+	// Adds the link to the end of the array.
+	array_push(
+		$links,
+		$settings_link
+	);
+	return $links;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UCSC Custom Functionality
  * Plugin URI: https://github.com/ucsc/ucsc-custom-functionality.git
- * Description: Contains custom functionality for UCSC WordPress Websites.
+ * Description: Adds custom functionality to UCSC WordPress Websites.
  * Version: 1.6.0
  * Author: UC Santa Cruz
  * Author URI: https://github.com/ucsc

--- a/plugin.php
+++ b/plugin.php
@@ -67,3 +67,31 @@ if ( file_exists( UCSC_DIR . '/lib/functions/settings.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/settings.php';
 }
 
+if ( ! function_exists( 'ucsc_enqueue_admin_styles' ) ) {
+	/**
+	* Enqueue admin settings styles
+	*
+	* No styles are enqueued for raw HTML in setting panel.
+	* In order to output HTML in the settings panel we need some basic styles.
+	*
+	* @since 1.7.0
+	* @author UCSC
+	* @link https://developer.wordpress.org/reference/hooks/admin_enqueue_scripts/#Example:_Load_CSS_File_from_a_plugin_on_specific_Admin_Page
+	*
+	*/
+
+	function ucsc_enqueue_admin_styles($hook){
+		$settings_css = plugin_dir_url(__FILE__) . 'lib/css/admin-settings.css';
+		$current_screen = get_current_screen();
+		// Check if it's "?page=ucsc-custom-functionality-settings." If not, just empty return. 
+		if ( strpos($current_screen->base, 'ucsc-custom-functionality-settings') === false) {
+			return;
+		} else {
+
+			// Load css.
+			wp_register_style( 'ucsc-cf-admin-settings', $settings_css,);
+			wp_enqueue_style( 'ucsc-cf-admin-settings');
+		}
+	}
+}
+add_action( 'admin_enqueue_scripts', 'ucsc_enqueue_admin_styles' );


### PR DESCRIPTION
## Overview

This change adds a "plugin settings" page under the **Settings** menu in the WordPress Dashboard. The rationale for this addition is described in Issue #15. Fixes #15.

This PR scaffolds a page for future customized settings, if necessary; but also allows us to output the plugin's `version number` and include some additional details about the plugin. As described in the associated issue, CampusPress does not output version numbers for plugins or themes. This gives us an easy place to check, if we're working in WordPress.

## Testing

These changes were successfully tested by creating a  `.zip` file and uploading to an external staging site.

## Changes

Adds a link to the page from the plugin on the Plugins page:
(Note: screenshot from local dev, which does show version no.)

![info-link](https://github.com/ucsc/ucsc-custom-functionality/assets/1000543/32a91f58-a04c-469f-a477-92e64f5cb737)

Adds a new menu item under the Settings menu in the Dashboard:

![info-menu-item](https://github.com/ucsc/ucsc-custom-functionality/assets/1000543/99dafee4-10f5-4b36-8acf-cb6c5bd550f9)

Provides a basic "settings" page that is mainly used for information but can be expanded on as future needs arise:

![info-page](https://github.com/ucsc/ucsc-custom-functionality/assets/1000543/f7fcac63-bb02-4ff7-8e1e-4e775742a6a5)



