### PR TITLE
Fix JS path for blocks

### DIFF
--- a/src/Assets/Assets_Enqueuer.php
+++ b/src/Assets/Assets_Enqueuer.php
@@ -38,7 +38,7 @@ class Assets_Enqueuer {
 			);
 
 			wp_enqueue_script(
-				$handle_file,
+				$handle_file . '_' . $block_name ,
 				$this->assets_path_uri . $block_name . '/' . $handle_file . '.js',
 				$args['dependencies'] ?? [],
 				$args['version'] ?? false,

--- a/src/Core.php
+++ b/src/Core.php
@@ -154,9 +154,10 @@ class Core {
 		}
 
 		foreach ( self::BLOCKS_NEWS_ONLY as $block_class => $block_path ) {
-			register_block_type( UCSC_DIR . $block_path );
-			
-			if ( ! class_exists( $block_class ) ) {
+//			register_block_type( UCSC_DIR . $block_path );
+            register_block_type_from_metadata( trailingslashit( UCSC_DIR . $block_path ) . '/block.json', [] );
+
+            if ( ! class_exists( $block_class ) ) {
 				continue;
 			}
 			( new $block_class )->init();

--- a/src/views/featured_news_block/block.json
+++ b/src/views/featured_news_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/magazine_block/block.json
+++ b/src/views/magazine_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/media_coverage_block/block.json
+++ b/src/views/media_coverage_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/news_block/block.json
+++ b/src/views/news_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/photo_of_the_week_block/block.json
+++ b/src/views/photo_of_the_week_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/photos_week_loop/block.json
+++ b/src/views/photos_week_loop/block.json
@@ -17,5 +17,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/post_overline_block/block.json
+++ b/src/views/post_overline_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/press_inquiries_block/block.json
+++ b/src/views/press_inquiries_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }

--- a/src/views/related_stories_block/block.json
+++ b/src/views/related_stories_block/block.json
@@ -16,5 +16,5 @@
 	},
     "editorStyle": [ "file:./style-index.css", "file:./index.css" ],
     "style": [ "file:./style-index.css" ],
-    "viewScript": [ "file:./index.js" ]
+    "editorScript": "file:./index.js"
 }


### PR DESCRIPTION
## What does this do/fix?

Fix JS path for blocks: replace `viewScript` with `editorScript`

