### PR TITLE
Fix SCSS build

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -1,2 +1,12 @@
-// Bring in mixins from the theme.
-@import "../../../../themes/ucsc-2022/src/scss/utilities/mixins";
+// Screen width breakpoints
+
+// The breakpoint where WP block columns switch from being stacked for mobile to
+// being actual columns.
+$wp-columns-unstack: 782px;
+
+@mixin media-query($size) {
+
+	@media screen and (min-width: $size) {
+		@content;
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

Skip requiring the presence of the `ucsc-2022` theme during build. Instead, copy the one mixin we use from the theme to the plugin.