### PR TITLE
fix: 🚑️ Update allowed taxonomies on News Block selector to include tags

### DIFF
--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -26,10 +26,11 @@ class News_Block extends ACF_Group {
 
 	public const ALLOWED_TAX = [
 		'academics',
-		'category',
 		'administration',
+		'category',
 		'colleges',
-		'section',
+        'people',
+		'tags',
 	];
 
 	protected function get_locations(): array {


### PR DESCRIPTION
Fixes #62