### PR TITLE
Fix: 🚑 Refactor `get_authors()` method in News Block Controller to only return co-authors

### DIFF
--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -151,42 +151,28 @@ class News_Block_Controller {
 	}
 
 	protected function get_authors(array $item): array {
-		if ( empty( $item['author'] ) && empty( $item['coauthors'] ) ) {
-			return [];
-		}
-
-		$authors = [];
-
-		if ( ! empty( $item['author'] ) ) {
-			$user = get_transient( $this->get_cache_key( 'user_' . $item['id'] ) );
-			if ( empty( $user ) ) {
-				$user = (new News_Request())->request( News_Request::ENDPOINT_BASE . 'users/' . $item['author'] );
-			}
-
-			if ( ! empty( $user ) ) {
-				$authors[] = $user['name'];
-				set_transient( $this->get_cache_key( 'user_' . $item['id'] ), $user, MINUTE_IN_SECONDS * 20 );
-			}
-		}
-
-		if ( ! empty( $item['coauthors'] ) ) {
-			foreach ( $item['coauthors'] as $author ) {
-				$user = get_transient( $this->get_cache_key( 'coauthor_' . $author ) );
-				if ( empty( $user ) ) {
-					$user = (new News_Request())->request( News_Request::ENDPOINT_BASE . 'coauthors/' . $author );
-				}
-
-				if ( empty( $user ) ) {
-					continue;
-				}
-
-				set_transient( $this->get_cache_key( 'coauthor_' . $author ), $user, MINUTE_IN_SECONDS * 20 );
-				$authors[] = $user['name'];
-			}
-		}
-
-		return $authors;
+	if (empty($item['coauthors'])) {
+		return [];
 	}
+
+	$authors = [];
+
+	foreach ($item['coauthors'] as $author) {
+		$user = get_transient($this->get_cache_key('coauthor_' . $author));
+		if (empty($user)) {
+			$user = (new News_Request())->request(News_Request::ENDPOINT_BASE . 'coauthors/' . $author);
+		}
+
+		if (empty($user)) {
+			continue;
+		}
+
+		set_transient($this->get_cache_key('coauthor_' . $author), $user, MINUTE_IN_SECONDS * 20);
+		$authors[] = $user['name'];
+	}
+
+	return $authors;
+}
 
 	protected function get_taxonomies(array $item, bool $is_tag = false) {
 		$categories = [];


### PR DESCRIPTION
## What does this do/fix?

Refactors the `get_authors()` array in the `News_Block_Controller.php` file to _only_ return CoAuthors.

Fixes #55 

## QA

### Screenshots/video
![news-block-authors-before](https://github.com/user-attachments/assets/61345f8c-fe9e-48d9-b104-667b7a5963e3)
_Before: Users and CoAuthors_

![news-block-authors-after](https://github.com/user-attachments/assets/f171a70f-a30d-42bb-9015-f24fe79ccc78)
_After: CoAuthors only_
