### PR TITLE
Feat: 🎉 Add ability to choose 3, 6, or 9 posts to be displayed in the News Block

### DIFF
--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -6,7 +6,7 @@ class News_Block extends ACF_Group {
 
 	public const NAME = 'news_query_block';
 
-	public const TITLE 		   = 'news_title';
+	public const TITLE        = 'news_title';
 	public const DESCRIPTION   = 'news_desc';
 	public const LAYOUT        = 'layout';
 	public const LAYOUT_LEFT   = 'layout_left';
@@ -29,7 +29,7 @@ class News_Block extends ACF_Group {
 		'administration',
 		'category',
 		'colleges',
-    'person',
+		'person',
 		'post_tag',
 	];
 
@@ -171,7 +171,7 @@ class News_Block extends ACF_Group {
 				6  => '6 Posts',
 				9  => '9 Posts'
 			],
-			'default_value' => 6, // Default to 6 posts
+			'default_value' => 6, // Default to  posts
 			'ui'            => 1,
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select the number of posts to display in the block.', 'ucsc' ),

--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -171,7 +171,7 @@ class News_Block extends ACF_Group {
 				6  => '6 Posts',
 				9  => '9 Posts'
 			],
-			'default_value' => 6, // Default to  posts
+			'default_value' => 3, // Default to 3 posts
 			'ui'            => 1,
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select the number of posts to display in the block.', 'ucsc' ),

--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -75,6 +75,7 @@ class News_Block extends ACF_Group {
 			$this->get_more_news_link_field(),
 			$this->get_taxonomies_list(),
 			$this->get_taxonomies_items(),
+			$this->get_posts_per_page_field(), // Add the dropdown field here
 		], $fields );
 	}
 
@@ -156,6 +157,24 @@ class News_Block extends ACF_Group {
 			'label' => esc_html__( 'More News Link', 'ucsc' ),
 			'name'  => self::MORE_NEWS_LINK,
 			'type'  => 'link',
+		];
+	}
+
+	private function get_posts_per_page_field(): array {
+		return [
+			'key'           => $this->get_field_key( 'posts_per_page', self::NAME ),
+			'label'         => esc_html__( 'Number of Posts to Show', 'ucsc' ),
+			'name'          => 'posts_per_page',
+			'type'          => 'select',
+			'choices'       => [
+				3  => '3 Posts',
+				6  => '6 Posts',
+				9  => '9 Posts'
+			],
+			'default_value' => 6, // Default to 6 posts
+			'ui'            => 1,
+			'return_format' => 'value',
+			'instructions'  => esc_html__( 'Select the number of posts to display in the block.', 'ucsc' ),
 		];
 	}
 

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -9,6 +9,7 @@ class News_Block_Controller {
 
 	public const POSTS    = 'news_posts';
 	public const PER_PAGE = 9; // can be moved to a separate field
+	private const CACHE_EXPIRY = MINUTE_IN_SECONDS * 20;
 
 	protected array $block;
 	private string $taxonomy;
@@ -119,7 +120,7 @@ class News_Block_Controller {
 		}
 
 		// Cache the response for 20 minutes
-		set_transient($this->get_cache_key(), $response, MINUTE_IN_SECONDS * 20);
+		set_transient($this->get_cache_key(), $response, self::CACHE_EXPIRY);
 
 		// Return only the number of items specified in the editor
 		return array_slice($items, 0, $this->posts_per_page);
@@ -148,7 +149,7 @@ class News_Block_Controller {
 			return [];
 		}
 
-		set_transient( $this->get_cache_key( 'attachment_' . $item['id'] ), $media, MINUTE_IN_SECONDS * 20 );
+		set_transient( $this->get_cache_key( 'attachment_' . $item['id'] ), $media, self::CACHE_EXPIRY );
 
 		return [
 			'raw_url'    => $media['guid']['rendered'] ?? '',
@@ -174,7 +175,7 @@ class News_Block_Controller {
 
 			if ( ! empty( $user ) ) {
 				$authors[] = $user['name'];
-				set_transient( $this->get_cache_key( 'user_' . $item['id'] ), $user, MINUTE_IN_SECONDS * 20 );
+				set_transient( $this->get_cache_key( 'user_' . $item['id'] ), $user, self::CACHE_EXPIRY );
 			}
 		}
 
@@ -189,7 +190,7 @@ class News_Block_Controller {
 					continue;
 				}
 
-				set_transient( $this->get_cache_key( 'coauthor_' . $author ), $user, MINUTE_IN_SECONDS * 20 );
+				set_transient( $this->get_cache_key( 'coauthor_' . $author ), $user, self::CACHE_EXPIRY );
 				$authors[] = $user['name'];
 			}
 		}
@@ -220,7 +221,7 @@ class News_Block_Controller {
 			return [];
 		}
 
-		set_transient( $this->get_cache_key( $taxonomy . '_' . $item['id'] ), $items, MINUTE_IN_SECONDS * 20 );
+		set_transient( $this->get_cache_key( $taxonomy . '_' . $item['id'] ), $items, self::CACHE_EXPIRY );
 
 		foreach ( $items as $category ) {
 			$categories[] = $category['name'];

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -8,7 +8,7 @@ use UCSC\Blocks\Request\News_Request;
 class News_Block_Controller {
 
 	public const POSTS    = 'news_posts';
-	public const PER_PAGE = 9; // can be moved to a separate field
+	public const PER_PAGE = 9;
 	private const CACHE_EXPIRY = MINUTE_IN_SECONDS * 20;
 
 	protected array $block;
@@ -40,8 +40,6 @@ class News_Block_Controller {
 		$this->hide_date      = (bool) get_field( News_Block::HIDE_DATE );
 		$this->hide_tags      = (bool) get_field( News_Block::HIDE_TAGS );
 		$this->hide_category  = (bool) get_field( News_Block::HIDE_CATEGORY );
-
-		// Retrieve the number of posts per page from the dropdown field
 		$this->posts_per_page = (int) get_field( 'posts_per_page' ) ?? self::PER_PAGE;
 	}
 
@@ -87,7 +85,6 @@ class News_Block_Controller {
 			return [];
 		}
 
-		// Fetch the cached response
 		$response = get_transient($this->get_cache_key());
 
 		if (empty($response)) {
@@ -104,7 +101,6 @@ class News_Block_Controller {
 
 		$items = [];
 
-		// Process the response and format the items
 		foreach ($response as $item) {
 			$items[] = [
 				'title'        => $item['title']['rendered'] ?? '',
@@ -119,10 +115,8 @@ class News_Block_Controller {
 			];
 		}
 
-		// Cache the response for 20 minutes
 		set_transient($this->get_cache_key(), $response, self::CACHE_EXPIRY);
 
-		// Return only the number of items specified in the editor
 		return array_slice($items, 0, $this->posts_per_page);
 	}
 

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -23,6 +23,7 @@ class News_Block_Controller {
 	private string $description;
 	private string $layout;
 	private array|string $more_news_link;
+	private int $posts_per_page;
 
 	public function __construct($block) {
 		$this->block          = (array) $block;
@@ -38,6 +39,9 @@ class News_Block_Controller {
 		$this->hide_date      = (bool) get_field( News_Block::HIDE_DATE );
 		$this->hide_tags      = (bool) get_field( News_Block::HIDE_TAGS );
 		$this->hide_category  = (bool) get_field( News_Block::HIDE_CATEGORY );
+
+		// Retrieve the number of posts per page from the dropdown field
+		$this->posts_per_page = (int) get_field( 'posts_per_page' ) ?? self::PER_PAGE;
 	}
 
 	public function get_title(): string {
@@ -86,7 +90,7 @@ class News_Block_Controller {
 
 		if ( empty( $response ) ) {
 			$response = ( new News_Request() )->request( News_Request::POSTS_ENDPOINT, [
-				'per_page'      => self::PER_PAGE,
+				'per_page'      => $this->posts_per_page, // Use the retrieved value here
 				$this->taxonomy => implode( ',', $this->taxonomy_ids ),
 			]);
 		}


### PR DESCRIPTION
## What does this do/fix?

The **News Block** currently shows six posts without the ability to reduce or increas the number. This PR adds the ability to select from 3, 6, or 9 posts in the **News Block**. It will default to six but a user may select three or nine.

## QA

### Links to relevant issues

Fixes: #66 


### Screenshots/video
https://github.com/user-attachments/assets/98d6d95c-5597-420b-aea1-e092d502f7e9

