### PR TITLE
Fix: 🚑  Edit Post Terms Block method to only target the Single Post Template

### DIFF
--- a/src/Template/Blocks_Render.php
+++ b/src/Template/Blocks_Render.php
@@ -50,7 +50,7 @@ class Blocks_Render {
 	}
 	
 	public function adjust_post_terms_block( $block_content = '', $block = [] ) {
-		if ( ! is_singular() || ! (  isset( $block['blockName'] ) && 'core/post-terms' === $block['blockName'] ) ) {
+		if ( ! is_single() || ! (  isset( $block['blockName'] ) && 'core/post-terms' === $block['blockName'] ) ) {
 			return $block_content;
 		}
 


### PR DESCRIPTION
The `adjust_post_terms_block()` method checks whether a template "`is_singular()`" before it executes. "`is_singular()`" applies to both a _single post_ and a _single page_. This means that _wherever_ we use a "Post Terms Block," it will get wrapped in these styles. 

This PR changes the condition to `is_single()` which will _only_ target a _single post_ and will allow users to use the default "Post Terms Block" elsewhere on the site (i.e., "Pages").

[ description ]

## QA

### Links to relevant issues

Fixes #67 

### Screenshots
![terms-before](https://github.com/user-attachments/assets/1b76fe2c-2255-4ce9-978b-bec65abe6a9a)
_Goes from this_

![terms-after](https://github.com/user-attachments/assets/74295e26-c19b-466e-a2da-04b010ebbd43)
_To this_
