### PR TITLE
fix: 🚑 Set environment type accurately so news block fetches data from the correct source

### DIFF
--- a/src/Request/News_Request.php
+++ b/src/Request/News_Request.php
@@ -45,14 +45,17 @@ class News_Request {
 		$env = wp_get_environment_type();
 
 		switch ( $env ) {
-			case 'test':
+            case 'production':
+                $base_url = 'https://news.ucsc.edu/';
+                break;
+			case 'staging':
 				$base_url = 'https://test-news-ucsc.pantheonsite.io/';
 				break;
-			case 'live':
-				$base_url = 'https://news.ucsc.edu/';
-				break;
+            case 'development':
+                $base_url = 'https://dev-news-ucsc.pantheonsite.io/';
+                break;    
 			default:
-				$base_url = 'https://dev-news-ucsc.pantheonsite.io/';
+				$base_url = 'https://news.ucsc.edu/';
 				break;
 		}
 


### PR DESCRIPTION
Fixes #74

## What does this do/fix?

Configure data endpoints by WordPress environment so the News Block fetches from the correct data source

## QA

### Links to relevant issues

- [Issue 74](https://github.com/ucsc/ucsc-custom-functionality/issues/74)
