### PR TITLE
fix: 🛠 Set default post header layout field correctly on creation

### DIFF
--- a/src/Blocks/Post_Header_Block.php
+++ b/src/Blocks/Post_Header_Block.php
@@ -47,8 +47,8 @@ class Post_Header_Block extends ACF_Group {
 			'key'           => $this->get_field_key( self::LAYOUT, self::NAME ),
 			'label'         => esc_html__( 'Layout', 'ucsc' ),
 			'choices'       => [
-				self::LAYOUT_BIG   => esc_html__( 'Big image', 'ucsc' ),
-				self::LAYOUT_SMALL => esc_html__( 'Small image', 'ucsc' )
+				self::LAYOUT_SMALL => esc_html__( 'Small image', 'ucsc' ),
+				self::LAYOUT_BIG   => esc_html__( 'Big image', 'ucsc' )
 			],
 			'default_value' => self::LAYOUT_SMALL,
 		];

--- a/src/Components/Post_Header_Block_Controller.php
+++ b/src/Components/Post_Header_Block_Controller.php
@@ -60,7 +60,7 @@ class Post_Header_Block_Controller {
 	}
 	
 	protected function get_layout() {
-		return get_field( Post_Header_Block::LAYOUT ) ?? Post_Header_Block::LAYOUT_BIG;
+		return get_field( Post_Header_Block::LAYOUT ) ?? Post_Header_Block::LAYOUT_SMALL;
 	}
 	
 }


### PR DESCRIPTION
## What does this do/fix?

Post Header block does not have enough bottom padding when a featured image is left out. I thought this was due to styling, but it is instead a misalignment of the ACF fields and the UI when a post is first created due to [a previous commit](https://github.com/ucsc/ucsc-custom-functionality/commit/af74f0cad3f5fa2661aaae6f3522a585dd0f1a3c). 
 
Fixes #76