### PR TITLE
feat: ✨ Add block variation for aligned images

### DIFF
--- a/assets/js/variations.js
+++ b/assets/js/variations.js
@@ -1,0 +1,37 @@
+const UCSC_ALIGNED_IMAGE = 'ucsc-custom-functionality/aligned-image';
+const { registerBlockVariation } = wp.blocks;
+
+/**
+ * Add core/group block variation for aligned images 
+ */
+registerBlockVariation( 'core/group', {
+    name: UCSC_ALIGNED_IMAGE,
+    title: 'Aligned Image',
+    description: 'Insert an aligned image so text can flow around it.',
+    keywords: [ "img", "photo", "picture", "image", "align", "left", "right" ],
+    attributes: {
+		layout: {
+			type: 'constrained'
+		},
+        allowedBlocks: [ "core/image", "core/spacer" ],
+        className: 'ucsc-aligned-image__container',
+        style: {
+            spacing: {
+                margin: {
+                    bottom: '1'
+                }
+            }    
+        }
+	},
+    isActive: ( { namespace, query } ) => {
+        return (
+            namespace === UCSC_ALIGNED_IMAGE
+            && query.postType === 'post'
+        );
+    },
+    icon: 'image-flip-horizontal',
+    scope: [ 'inserter' ],
+    innerBlocks: [
+        ['core/image',{"className":"ucsc-aligned-image__item","sizeSlug":"large","linkDestination":"none","align":"center","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}}]
+    ]
+});

--- a/lib/functions/scripts.php
+++ b/lib/functions/scripts.php
@@ -24,3 +24,22 @@ if ( file_exists( UCSC_DIR . '/lib/functions/scripts/ga.php' ) ) {
 if ( file_exists( UCSC_DIR . '/lib/functions/scripts/site-improve.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/scripts/site-improve.php';
 }
+
+/**
+ * Add group block variation for aligned images
+ *
+ * @since 1.8.5
+ * @author UCSC
+ * @link  https://developer.wordpress.org/news/2024/08/how-to-extend-a-wordpress-block/#adding-custom-functionality
+ */
+function ucsc_cf_enqueue_block_variations()
+{
+    wp_enqueue_script(
+        'ucsc-cf-enqueue-block-variations',
+        UCSC_PLUGIN_URL . 'assets/js/variations.js',
+        array('wp-blocks', 'wp-dom-ready'),
+        wp_get_theme()->get('Version'),
+        false
+    );
+}
+add_action('enqueue_block_editor_assets', 'ucsc_cf_enqueue_block_variations');


### PR DESCRIPTION
Fixes #80

This adds a block variation called "Aligned Image." The aligned image block is a pre-configured group block with an image block placeholder. This facilitates adding an aligned image to a post or page that stays within the bounds of the post body. 

## Tests

To test, invoke the block inserter and search "image." You should see "Aligned Image." Insert that block and then add an image using the image block already inside the group block.

![screenshot-2025-05-08-182006](https://github.com/user-attachments/assets/9cd8eab7-9800-4c30-a462-f3addf3ce362)

![screenshot-2025-05-08-182126](https://github.com/user-attachments/assets/49716a3a-4ea3-4f6b-8f84-aba1d0d8c995)
