### PR TITLE
Fix: 🐛 Add `alt_text` to News Block images

### DIFF
--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -151,7 +151,7 @@ class News_Block_Controller {
 			'height'     => $media['media_details']['height'] ?? 0,
 			'image_meta' => $media['media_details']['image_meta'] ?? [],
 			'sizes'      => $media['media_details']['sizes'] ?? [],
-			'alt'        => $media['alt_text'] ?? '', // <-- Added alt text here
+			'alt'        => $media['alt_text'] ?? '',
 		];
 	}
 

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -151,6 +151,7 @@ class News_Block_Controller {
 			'height'     => $media['media_details']['height'] ?? 0,
 			'image_meta' => $media['media_details']['image_meta'] ?? [],
 			'sizes'      => $media['media_details']['sizes'] ?? [],
+			'alt'        => $media['alt_text'] ?? '', // <-- Added alt text here
 		];
 	}
 

--- a/src/views/news_block/index.php
+++ b/src/views/news_block/index.php
@@ -42,7 +42,7 @@ if ( empty( $items ) ) {
 				<?php if ( ! empty( $item['image'] ) ) : ?>
 					<img 
 	src="<?php echo esc_url( $item['image']['raw_url'] );?>" 
-	srcset="<?php echo $c->build_srcset( $item['image']['sizes']) ;?>" 
+	srcset="<?php echo esc_attr( $c->build_srcset( $item['image']['sizes']) );?>" 
 	class="ucsc-news-block__card-image"
 	alt="<?php echo esc_attr( $item['image']['alt'] ?? '' ); ?>"
 />

--- a/src/views/news_block/index.php
+++ b/src/views/news_block/index.php
@@ -8,12 +8,12 @@ $c = new \UCSC\Blocks\Components\News_Block_Controller( $block );
 $items = $c->get_items();
 
 if ( is_admin() && empty( $items ) ) {
-    ?>
-    <section <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-        <h3><?php echo esc_html__( 'Select a taxonomy and term(s) in the News Block settings', 'ucsc' ); ?></h3>
-    </section>
-    <?php
-    return;
+	?>
+	<section <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
+		<h3><?php echo esc_html__( 'Select a taxonomy and term(s) in the News Block settings', 'ucsc' ); ?></h3>
+	</section>
+	<?php
+	return;
 }
 
 if ( empty( $items ) ) {
@@ -21,90 +21,90 @@ if ( empty( $items ) ) {
 }
 ?>
 <section <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-    <?php if ( ! empty( $c->get_title() ) || ! empty( $c->get_description() ) ) : ?>
-        <div class="ucsc-news-block__header<?php echo esc_attr( $c->get_alignment() ); ?>">
-            <?php if ( ! empty( $c->get_title() ) ) : ?>
-                <h2 class="ucsc-news-block__header-title"><?php echo $c->get_title(); ?></h2>
-            <?php endif; ?>
+	<?php if ( ! empty( $c->get_title() ) || ! empty( $c->get_description() ) ) : ?>
+		<div class="ucsc-news-block__header<?php echo esc_attr( $c->get_alignment() ); ?>">
+			<?php if ( ! empty( $c->get_title() ) ) : ?>
+				<h2 class="ucsc-news-block__header-title"><?php echo $c->get_title(); ?></h2>
+			<?php endif; ?>
 
-            <?php if ( ! empty( $c->get_description() ) ) : ?>
-                <div class="ucsc-news-block__header-description"><?php echo $c->get_description(); ?></div>
-            <?php endif; ?>
-        </div>
-    <?php endif; ?>
+			<?php if ( ! empty( $c->get_description() ) ) : ?>
+				<div class="ucsc-news-block__header-description"><?php echo $c->get_description(); ?></div>
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
 
-    <?php if ( count($items) < 1 ) { ?>
-        <p><?php echo _e( 'No articles found', 'ucsc' ); ?></p>
-    <?php } else { ?>
-        <div class="ucsc-news-block__cards-wrapper">
-        <?php foreach ( $items as $item ) : ?>
-            <a href="<?php echo esc_url( $item['permalink'] );?>" class="ucsc-news-block__card">
-                <?php if ( ! empty( $item['image'] ) ) : ?>
-                    <img 
-    src="<?php echo esc_url( $item['image']['raw_url'] );?>" 
-    srcset="<?php echo $c->build_srcset( $item['image']['sizes']) ;?>" 
-    class="ucsc-news-block__card-image"
-    alt="<?php echo esc_attr( $item['image']['alt'] ?? '' ); ?>"
+	<?php if ( count($items) < 1 ) { ?>
+		<p><?php echo _e( 'No articles found', 'ucsc' ); ?></p>
+	<?php } else { ?>
+		<div class="ucsc-news-block__cards-wrapper">
+		<?php foreach ( $items as $item ) : ?>
+			<a href="<?php echo esc_url( $item['permalink'] );?>" class="ucsc-news-block__card">
+				<?php if ( ! empty( $item['image'] ) ) : ?>
+					<img 
+	src="<?php echo esc_url( $item['image']['raw_url'] );?>" 
+	srcset="<?php echo $c->build_srcset( $item['image']['sizes']) ;?>" 
+	class="ucsc-news-block__card-image"
+	alt="<?php echo esc_attr( $item['image']['alt'] ?? '' ); ?>"
 />
-                <?php endif; ?>
+				<?php endif; ?>
 
-                <?php if ( ! empty( $item['categories'] ) ) : ?>
-                    <span class="ucsc-news-block__card-categories">
-                        <?php echo esc_html( implode( ', ', $item['categories'] ) ); ?>
-                    </span>
-                <?php endif; ?>
-                
-                <h3 class="ucsc-news-block__card-title">
-                    <span class="ucsc-news-block__card-title--inner">
-                        <?php echo esc_html( $item['title'] );?>
-                    </span>
-                </h3>
-    
-                <?php if ( ! empty( $item['excerpt'] ) ) : ?>
-                    <div class="ucsc-news-block__card-excerpt">
-                        <?php echo $item['excerpt']; ?>
-                    </div>
-                <?php endif; ?>
+				<?php if ( ! empty( $item['categories'] ) ) : ?>
+					<span class="ucsc-news-block__card-categories">
+						<?php echo esc_html( implode( ', ', $item['categories'] ) ); ?>
+					</span>
+				<?php endif; ?>
+				
+				<h3 class="ucsc-news-block__card-title">
+					<span class="ucsc-news-block__card-title--inner">
+						<?php echo esc_html( $item['title'] );?>
+					</span>
+				</h3>
+	
+				<?php if ( ! empty( $item['excerpt'] ) ) : ?>
+					<div class="ucsc-news-block__card-excerpt">
+						<?php echo $item['excerpt']; ?>
+					</div>
+				<?php endif; ?>
 
-                <?php if ( ! empty( $item['publish_date'] ) || ! empty( $item['authors'] ) || ! empty( $item['tags'] ) ) : ?>
-                    <div class="ucsc-news-block__card-meta">
-                        <?php if ( ! empty( $item['publish_date'] ) ) : ?>
-                            <time class="ucsc-news-block__card-date" datetime="<?php echo esc_attr( $item['raw_date']); ?>">
-                                <?php echo esc_html( $item['publish_date'] ); ?>
-                            </time>
-                        <?php endif; ?>
+				<?php if ( ! empty( $item['publish_date'] ) || ! empty( $item['authors'] ) || ! empty( $item['tags'] ) ) : ?>
+					<div class="ucsc-news-block__card-meta">
+						<?php if ( ! empty( $item['publish_date'] ) ) : ?>
+							<time class="ucsc-news-block__card-date" datetime="<?php echo esc_attr( $item['raw_date']); ?>">
+								<?php echo esc_html( $item['publish_date'] ); ?>
+							</time>
+						<?php endif; ?>
 
-                        <?php if ( ! empty( $item['publish_date'] ) && ! empty( $item['authors'] ) ) : ?>
-                        <span class="ucsc-news-block__meta-separator"></span>
-                        <?php endif; ?>
-            
-                        <?php if ( ! empty( $item['authors'] ) ) : ?>
-                            <span class="ucsc-news-block__card-authors">
-                                <?php echo count( $item['authors'] ) > 1 ? esc_html__( 'By', 'ucsc' ) . ' ' . implode( ' and ', $item['authors'] ) : reset( $item['authors'] ); ?>
-                            </span>
-                        <?php endif; ?>
-    
-                        <?php if ( ! empty( $item['tags'] ) ) : ?>
-                            <span class="ucsc-news-block__card-tags">
-                            <?php foreach ($item['tags'] as $tag ) { ?>
-                                <span class="ucsc-news-block__card-tag">
-                                    <?php echo esc_html( $tag ); ?>
-                                </span>
-                            <?php } ?>
-                        </span>
-                        <?php endif; ?>
-                    </div>
-                <?php endif; ?>
-            </a>
-        <?php endforeach; ?>
-        </div>
+						<?php if ( ! empty( $item['publish_date'] ) && ! empty( $item['authors'] ) ) : ?>
+						<span class="ucsc-news-block__meta-separator"></span>
+						<?php endif; ?>
+			
+						<?php if ( ! empty( $item['authors'] ) ) : ?>
+							<span class="ucsc-news-block__card-authors">
+								<?php echo count( $item['authors'] ) > 1 ? esc_html__( 'By', 'ucsc' ) . ' ' . implode( ' and ', $item['authors'] ) : reset( $item['authors'] ); ?>
+							</span>
+						<?php endif; ?>
+	
+						<?php if ( ! empty( $item['tags'] ) ) : ?>
+							<span class="ucsc-news-block__card-tags">
+							<?php foreach ($item['tags'] as $tag ) { ?>
+								<span class="ucsc-news-block__card-tag">
+									<?php echo esc_html( $tag ); ?>
+								</span>
+							<?php } ?>
+						</span>
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
+			</a>
+		<?php endforeach; ?>
+		</div>
 
-        <?php if ( ! empty( $c->get_more_news_link() ) ) : ?>
-            <div class="ucsc-news-block__more-news is-style-ucsc-blue">
-                <a href="<?php echo esc_url( $c->get_more_news_link()['url'] ); ?>" target="<?php echo esc_attr( $c->get_more_news_link()['target'] ); ?>" class="ucsc-news-block__more-news-link wp-element-button">
-                    <?php echo esc_html( $c->get_more_news_link()['title'] ); ?>
-                </a>
-            </div>
-        <?php endif; ?>
-    <?php } ?>
+		<?php if ( ! empty( $c->get_more_news_link() ) ) : ?>
+			<div class="ucsc-news-block__more-news is-style-ucsc-blue">
+				<a href="<?php echo esc_url( $c->get_more_news_link()['url'] ); ?>" target="<?php echo esc_attr( $c->get_more_news_link()['target'] ); ?>" class="ucsc-news-block__more-news-link wp-element-button">
+					<?php echo esc_html( $c->get_more_news_link()['title'] ); ?>
+				</a>
+			</div>
+		<?php endif; ?>
+	<?php } ?>
 </section>

--- a/src/views/news_block/index.php
+++ b/src/views/news_block/index.php
@@ -40,7 +40,12 @@ if ( empty( $items ) ) {
         <?php foreach ( $items as $item ) : ?>
             <a href="<?php echo esc_url( $item['permalink'] );?>" class="ucsc-news-block__card">
                 <?php if ( ! empty( $item['image'] ) ) : ?>
-                    <img src="<?php echo esc_url( $item['image']['raw_url'] );?>" srcset="<?php echo $c->build_srcset( $item['image']['sizes']) ;?>" class="ucsc-news-block__card-image" />
+                    <img 
+    src="<?php echo esc_url( $item['image']['raw_url'] );?>" 
+    srcset="<?php echo $c->build_srcset( $item['image']['sizes']) ;?>" 
+    class="ucsc-news-block__card-image"
+    alt="<?php echo esc_attr( $item['image']['alt'] ?? '' ); ?>"
+/>
                 <?php endif; ?>
 
                 <?php if ( ! empty( $item['categories'] ) ) : ?>


### PR DESCRIPTION
## What does this do/fix?

The News Block does not currently render  **alt text** for the Featured Image on the front end. This PR Fixes #79, which describes the issue in detail.

## QA

### Screenshots

**Before:**
![news-block-no-alt](https://github.com/user-attachments/assets/5115ad6b-e34e-4e1c-b32c-6cb03dcc22d8)

**After:**
![news-block-with-alt](https://github.com/user-attachments/assets/bb0819f2-09bb-4df5-8fe3-dde97a00a6ba)


## Tests

### Does this have tests?

Test this by building the News Block, then checking it with the WAVE Browser extension.
