### PR TITLE
Fix oEmbed issues

### DIFF
--- a/lib/functions/scripts.php
+++ b/lib/functions/scripts.php
@@ -15,6 +15,7 @@
 if ( file_exists( UCSC_DIR . '/lib/functions/scripts/disable-xmlrpc.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/scripts/disable-xmlrpc.php';
 }
+
 // Add Google TagManager.
 if ( file_exists( UCSC_DIR . '/lib/functions/scripts/ga.php' ) ) {
 	include_once UCSC_DIR . '/lib/functions/scripts/ga.php';

--- a/plugin.php
+++ b/plugin.php
@@ -1,5 +1,4 @@
 <?php declare(strict_types=1);
-
 /**
  * Plugin Name: UCSC Custom Functionality
  * Plugin URI: https://github.com/ucsc/ucsc-custom-functionality.git
@@ -11,40 +10,6 @@
  *
  * @package ucsc-custom-functionality
  */
-
-if ( ! function_exists( 'ucsc_custom_functionality_hidden' ) ) {
-	/**
-	* Don't Update Plugin
-	*
-	* @since 1.0.0
-	*
-	* This prevents you being prompted to update if there's a public plugin
-	* with the same name.
-	*
-	* @author Mark Jaquith
-	 *
-	 * @link http://markjaquith.wordpress.com/2009/12/14/excluding-your-plugin-or-theme-from-update-checks/
-	*
-	* @param array  $r, request arguments
-	* @param string $url, request url
-	 *
-	 * @return array request arguments
-	*/
-
-	function ucsc_custom_functionality_hidden( array $r, string $url ): array {
-		if ( 0 !== strpos( $url, 'http://api.wordpress.org/plugins/update-check' ) ) {
-			return $r; // Not a plugin update request. Bail immediately.
-		}
-		$plugins = unserialize( $r['body']['plugins'] );
-		unset( $plugins->plugins[ plugin_basename( __FILE__ ) ] );
-		unset( $plugins->active[ array_search( plugin_basename( __FILE__ ), $plugins->active ) ] );
-		$r['body']['plugins'] = serialize( $plugins );
-
-		return $r;
-	}
-}
-
-add_filter( 'http_request_args', 'ucsc_custom_functionality_hidden', 5, 2 );
 
 // Set plugin directory.
 define( 'UCSC_DIR', dirname( __FILE__ ) );


### PR DESCRIPTION
Fixes #83

Resolves issue of oEmbeds not working on UCSC WordPress websites that use this plugin.

## Tests

To test this change, embed a *post* URL from your site on a page in the same site, then switch to this branch.

You should see the default embed style after switcing to this branch (clearing cache, transients, etc.).