### PR TITLE
feat: ✨ Add a toggle button in the admin dashboard for XMLRPC to enable external editing when needed

### DIFF
--- a/lib/functions/scripts/disable-xmlrpc.php
+++ b/lib/functions/scripts/disable-xmlrpc.php
@@ -2,20 +2,25 @@
 
 /**
  * Disable XMLRPC
-
+ *
  * /xmlrpc.php can be used to brute force admin usernames and passwords.
-
+ *
  * see: https://pantheon.io/docs/wordpress-best-practices#avoid-xml-rpc-attacks
+ *
+ * XMLRPC is disabled by default. Site administrators can re-enable it from
+ * Settings → UCSC Custom Functionality.
  */
 
-add_filter(
-	'xmlrpc_methods',
-	function () {
-		return array();
-	},
-	PHP_INT_MAX
-);
+if ( ! (bool) get_option( 'ucsc_enable_xmlrpc', false ) ) {
+	add_filter(
+		'xmlrpc_methods',
+		function () {
+			return array();
+		},
+		PHP_INT_MAX
+	);
 
-// Removes the link from the <head>.
-// Avoids a11y issue with broken link
-remove_action('wp_head', 'rsd_link');
+	// Removes the link from the <head>.
+	// Avoids a11y issue with broken link
+	remove_action( 'wp_head', 'rsd_link' );
+}

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -109,7 +109,7 @@ if (! function_exists('ucsc_render_plugin_settings_page')) {
         <div class="wrap cf-admin-settings-page">
             <h1><?php echo esc_html($plugin_data['Name']); ?></h1>
             <h2>Version: <?php echo esc_html($plugin_data['Version']); ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
-            <p><?php echo esc_html($plugin_data['Description']); ?></p>
+            <p><?php echo wp_kses_post($plugin_data['Description']); ?></p>
             <hr>
             <h3>Features added by this plugin:</h3>
             <ul>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Add Plugin settings and info page
  *
@@ -13,12 +14,78 @@
 
 /** Register new menu and page */
 
-if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
-	function ucsc_add_settings_page() {
-		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
-	}
+if (! function_exists('ucsc_add_settings_page')) {
+    function ucsc_add_settings_page()
+    {
+        add_options_page('UCSC Custom Functionality plugin page', 'UCSC Custom Functionality', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page');
+    }
 }
-add_action( 'admin_menu', 'ucsc_add_settings_page' );
+add_action('admin_menu', 'ucsc_add_settings_page');
+
+
+/** Register plugin settings via the Settings API */
+
+if (! function_exists('ucsc_register_plugin_settings')) {
+    function ucsc_register_plugin_settings()
+    {
+        register_setting(
+            'ucsc_custom_functionality',
+            'ucsc_enable_xmlrpc',
+            array(
+                'type'              => 'boolean',
+                'description'       => 'Whether XML-RPC is enabled on this site.',
+                'sanitize_callback' => static function ($value) {
+                    return ! empty($value);
+                },
+                'default'           => false,
+                'show_in_rest'      => false,
+            )
+        );
+
+        add_settings_section(
+            'ucsc_security_section',
+            'Security',
+            static function () {
+                echo '<p>Security features provided by this plugin.</p>';
+            },
+            'ucsc-custom-functionality-settings'
+        );
+
+        add_settings_field(
+            'ucsc_enable_xmlrpc',
+            'Enable XML-RPC',
+            'ucsc_render_enable_xmlrpc_field',
+            'ucsc-custom-functionality-settings',
+            'ucsc_security_section',
+            array('label_for' => 'ucsc_enable_xmlrpc')
+        );
+    }
+}
+add_action('admin_init', 'ucsc_register_plugin_settings');
+
+
+if (! function_exists('ucsc_render_enable_xmlrpc_field')) {
+    function ucsc_render_enable_xmlrpc_field()
+    {
+        $enabled = (bool) get_option('ucsc_enable_xmlrpc', false);
+?>
+        <label for="ucsc_enable_xmlrpc">
+            <input
+                type="checkbox"
+                id="ucsc_enable_xmlrpc"
+                name="ucsc_enable_xmlrpc"
+                value="1"
+                <?php checked($enabled); ?> />
+            Allow requests to <code>/xmlrpc.php</code> on this site.
+        </label>
+        <p class="description">
+            XML-RPC is disabled by default because <code>/xmlrpc.php</code> can be used as an attack vector.
+            Only enable this if a specific integration (for example, the Jetpack mobile app or a remote publishing tool) requires it.
+            See <a href="https://docs.pantheon.io/guides/wordpress-developer/xml-rpc-attacks" rel="noopener noreferrer">Pantheon&rsquo;s guidance on XML-RPC attacks</a>.
+        </p>
+    <?php
+    }
+}
 
 
 /** 
@@ -30,30 +97,40 @@ add_action( 'admin_menu', 'ucsc_add_settings_page' );
  *
  */
 
-if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
-	function ucsc_render_plugin_settings_page() {
-		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
-		?>
-		<div class="wrap cf-admin-settings-page">
-		<h1><?php echo $plugin_data['Name']; ?></h1>
-		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
-		<p><?php echo $plugin_data['Description']; ?></p>
-		<hr>
-		<h3>Features added by this plugin:</h3>
-		<ul>
-			<li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
-			<li><strong>Shortcodes:</strong>
-				<ul>
-					<li><code>[site-search]</code>: Inserts the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
-					<li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode('[copyright]')?>)</li>
-					<li><code>[last-modified]</code>: Displays the <i>last modified</i> date of a page</li>
-				</ul>
-			</li>
-		</ul>
-		</div>
-		<?php
-	}
+if (! function_exists('ucsc_render_plugin_settings_page')) {
+    function ucsc_render_plugin_settings_page()
+    {
+        if (! current_user_can('manage_options')) {
+            return;
+        }
+
+        $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
+    ?>
+        <div class="wrap cf-admin-settings-page">
+            <h1><?php echo esc_html($plugin_data['Name']); ?></h1>
+            <h2>Version: <?php echo esc_html($plugin_data['Version']); ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
+            <p><?php echo esc_html($plugin_data['Description']); ?></p>
+            <hr>
+            <h3>Features added by this plugin:</h3>
+            <ul>
+                <li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
+                <li><strong>Shortcodes:</strong>
+                    <ul>
+                        <li><code>[site-search]</code>: Inserts the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
+                        <li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode('[copyright]') ?>)</li>
+                        <li><code>[last-modified]</code>: Displays the <i>last modified</i> date of a page</li>
+                    </ul>
+                </li>
+            </ul>
+            <hr>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields('ucsc_custom_functionality');
+                do_settings_sections('ucsc-custom-functionality-settings');
+                submit_button();
+                ?>
+            </form>
+        </div>
+<?php
+    }
 }
-
-
-


### PR DESCRIPTION
Fixes #91

## What does this do/fix?

Adds a checkbox to the plugin settings screen to enable XMLRPC connections to a site.   

## Tests

- Turning on XMLRPC adds a meta tag to the document head with the URL for connecting to the XML-RPC endpoint.
- Connecting to WordPress from an external editor like MarsEdit (Mac) should work.