### PR TITLE
Update `release.yml` to use `ucsc/actions` release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
         tags:
             - "v*.*.*"
             - "v*.*.*-rc.*"
+    workflow_dispatch:
 
 permissions:
     contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,32 @@
+# Caller workflow — drop this into each consuming repo at:
+#   .github/workflows/release.yml
+#
+# Update the `uses` path to match your shared-workflows repo and tag.
+# Update `zip-name` to match the package name in that repo's package.json.
+
 name: Build and release
 
 on:
     push:
         tags:
-            - 'v*.*.*'
-            - 'v*.*.*-rc.*'
-        
+            - "v*.*.*"
+            - "v*.*.*-rc.*"
+
 permissions:
     contents: write
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v4.2.2
-            - uses: actions/setup-node@v3.9.1
-              with:
-                  node-version: 20
-                  cache: 'npm'
-
-            - name: Install Composer dependencies
-              run: |
-                  composer install --optimize-autoloader --ignore-platform-reqs --no-dev
-
-            - name: Install Node dependencies
-              run: npm install
-              
-            - name: Build plugin assets
-              run: ./node_modules/.bin/wp-scripts build
-
-            - name: Package plugin
-              run: ./node_modules/.bin/wp-scripts plugin-zip
-
-            - name: Release
-              uses: softprops/action-gh-release@v1
-              with:
-                  files: ucsc-custom-functionality.zip
-                  generate_release_notes: true
+    release:
+        # Point this at your shared repo. Pin to a tag for stability.
+        uses: ucsc/actions/.github/workflows/release.yml@v1
+        with:
+            zip-name: ${{ github.event.repository.name }}.zip
+            #
+            # DEFAULTS
+            # Uncomment the following lines to adjust the defaults:
+            #
+            # node-version: '24'
+            # build-command: 'build'
+            # use-composer: true
+            # composer-args: '--no-dev --no-progress --optimize-autoloader'
+            # generate-release-notes: true

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "name": "ucsc/custom-functionality",
+    "description": "UCSC Custom Functionality WordPress Plugin",
+    "license": "GPL-2.0-or-later",
     "require-dev": {
         "wp-coding-standards/wpcs": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34e8a7a529a4a95bf3459d704bbb3dcf",
+    "content-hash": "55ad500a7aa601402d9947e2b921f6d5",
     "packages": [],
     "packages-dev": [
         {
@@ -84,16 +84,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -103,18 +103,13 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -122,21 +117,49 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -192,10 +215,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## What does this do/fix?

Fixes #96 
Updates the `release.yml` fine to utilize the "global" [ucsc/actions](https://github.com/ucsc/actions) workflow.

## Tests

Issue a new release with a tag. Push with `--follow-tags` flag. 
To test the workflow without a tag, issue a Github CLI command:
`gh workflow run release.yml --ref name-of-branch`
This should initialize the workflow; however, _it will fail_ because there is no tag. 
<img width="318" height="142" alt="image" src="https://github.com/user-attachments/assets/e81b9c3d-c5dd-4e55-9525-8446818b08fc" />
Any errors that occur prior to this failure have been fixed, namely:
`composer.json` needed to be updated to include a _Name_, _Description_ and _License_. `composer.lock` file updated to reflect this.