### PR TITLE
docs: add CLAUDE.md and plugin audit ROADMAP.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+nvm use              # Node 20.18.0 (.nvmrc)
+npm install && composer install
+
+npm run dev          # webpack watch
+npm run build        # production build into build/ (required — see "Build output" below)
+npm run lint:js      # eslint + --fix on src/**/*.js
+npm run lint:css     # stylelint + --fix on src/**/*.scss
+composer lint        # phpcs (WordPress-Extra + WordPress-Docs, .phpcs.xml.dist)
+composer lint-fix    # phpcbf
+
+npm run release      # commit-and-tag-version: bumps package.json, package-lock.json,
+                     # plugin.php header (via wp-plugin-version-updater.js), CHANGELOG.md
+git push --follow-tags origin main   # tag push triggers .github/workflows/release.yml
+```
+
+There is **no test suite**. Verification is: `composer lint`, `npm run lint:js`/`lint:css`, `npm run build`, then manual check in a WordPress install.
+
+Release CI delegates to the shared reusable workflow `ucsc/actions/.github/workflows/release.yml@v1` — build/packaging changes usually belong in that repo, not here. Tags: `v1.2.3` or `v1.2.3-rc.1`.
+
+## Runtime requirements
+
+- **ACF PRO is a hard dependency.** `plugin.php` only calls `Core::instance()->init()` on `plugins_loaded` (priority 100) if `acf_add_local_field_group()` exists. Without ACF, nothing in `src/` runs.
+- **`UCSC_NEWS_SITE`** — when defined `true`, unlocks the news-only blocks, the Photo of the Week post type, custom templates, query/integration subscribers, and object meta. Every gate routes through `Core::is_news_site()`. Only the News block and the `lib/` procedural features are active on non-news sites.
+
+## Architecture
+
+Two layers coexist:
+
+- **`lib/functions/`** — legacy procedural code (admin menus, settings page, shortcodes, GTM/SiteImprove/xmlrpc scripts), included directly by [plugin.php](plugin.php). Global functions here must be `ucsc_`-prefixed and wrapped in `function_exists()` guards (phpcs enforces the prefix).
+- **`src/`** — PSR-4 `UCSC\Blocks\` (note: namespace root is `Blocks`, so `src/Blocks/Foo.php` is `UCSC\Blocks\Blocks\Foo`). [src/Core.php](src/Core.php) is the singleton bootstrap and the registry of every block.
+
+### The ACF block triad
+
+Each custom block is three coordinated pieces:
+
+| Piece | Location | Role |
+|---|---|---|
+| Field group | `src/Blocks/<Name>_Block.php` | extends `ACF_Group` (or `Query_Loop`); defines ACF fields and the `block` location rule |
+| Controller | `src/Components/<Name>_Block_Controller.php` | reads `get_field()` into typed props, queries/prepares data for the view |
+| View | `src/views/<dir>/` | `block.json` + `index.php` render template + `index.js` + `style.scss`/`editor.scss` |
+
+`block.json` declares `"acf": { "mode": "preview", "renderTemplate": "index.php" }`. Registration happens in `Core::init_blocks()` via `register_block_type_from_metadata()` against **`build/views/<dir>/block.json`**, with `render_callback` pointed at `Core::render_template()`.
+
+`Core::render_template()` rewrites `build/views/` back to `src/views/` before including the template ([src/Core.php:69-78](src/Core.php#L69-L78)). Consequence: **PHP view edits take effect immediately; JS/SCSS edits require a build.** The `index.php` in `build/` is never executed.
+
+ACF field *names* are class constants on the block class (`News_Block::TITLE`, etc.) and are referenced by both the field group and the controller — never hardcode the string in one place and the constant in the other. Field *keys* are composed by `With_Get_Field_Key::get_field_key( $name, $group_name )` → `"{group}_{name}"`; ACF filters like `acf/fields/select/query/key=…` in `src/Hooks/` depend on that exact composition.
+
+### Adding a block
+
+1. `src/views/<dir>/` with `block.json` (name `ucsc-custom-functionality/<slug>`), `index.php`, `index.js`, `style.scss`, `editor.scss`.
+2. Field-group class in `src/Blocks/`, controller in `src/Components/`.
+3. Register in `Core::BLOCKS_PUBLIC` (all sites) or `Core::BLOCKS_NEWS_ONLY` (news only).
+
+The path in those constants **must match the `src/views/` directory name** — webpack mirrors the source directory into `build/views/<same-name>/`, not the block.json slug. A mismatch silently skips registration. (`Magazine_Block` currently maps to `/build/views/magazine-block` while the source dir is `src/views/magazine-lock` — likely broken.)
+
+### Query-loop blocks
+
+`Blocks\Query_Loop` (field side) + `Components\Query_Loop_Controller` (data side) implement three editor-selectable modes: `latest`, `automatic` (taxonomy term), `manual` (post_object repeater). Subclasses override `$number_of_posts_display`, `$post_types`, `$max_manual_cards`, and implement `prepare_posts_for_display()`.
+
+### The News block is remote
+
+Unlike every other block, `News_Block_Controller` pulls posts over REST from the news site via `Request\News_Request`, which picks its base URL from `wp_get_environment_type()` (production → `news.ucsc.edu`, staging/development → the Pantheon envs). Taxonomy/term choices for the editor are loaded through `Hooks\News_Blocks_Hooks` and cached in transients for 20 minutes, keyed by field key. When editor dropdowns look stale, delete those transients.
+
+### Assets
+
+`Assets\Assets_Enqueuer` does not enqueue per registered class — it scans `WP_Block_Type_Registry` for names containing `ucsc-custom-functionality/`, then loads `build/views/<last-segment-of-block-name>/index.asset.php` for version/deps. So the block.json slug's last segment must also match the build directory name.
+
+Two extra webpack entries in [webpack.config.js](webpack.config.js) compile `assets/scss/blocks/*.scss` into `build/css/`, attached to *core* blocks via `wp_enqueue_block_style()` in `Assets_Subscriber` (`core/post-terms`, `outermost/social-sharing`).
+
+### Templates and core-block filtering (news sites only)
+
+`Template\Template` subclasses (`Post_Single`, `Photo_Of_The_Week_Archive`) inject block templates through the `get_block_templates` filter, creating a `wp_template` post from `src/views/templates/*.html` on first load and tagging it with the `wp_theme` term `ucsc-2022` (`Template::NAMESPACE`). That namespace ties the templates to the UCSC theme; changing themes orphans them.
+
+`Template\Blocks_Render` (via `Template_Subscriber`) filters `render_block` to rewrite core block output — Co-Authors Plus in `core/post-author-name`, caption/description appended to `core/post-featured-image`, wrappers on `core/post-terms` and `outermost/social-sharing`.
+
+## Conventions
+
+- `declare(strict_types=1)` on all `src/` files; `lib/` files need a file-level docblock.
+- Text domain is `ucsc`; phpcs `minimum_supported_wp_version` is 4.9.
+- `build/` and `vendor/` are gitignored but both ship in the release zip (`package.json` `files`, `.deployignore`).
+- Branches: `feature/…`, `fix/…`, `chore/…` off `main`; commit messages follow Conventional Commits (CHANGELOG is generated from them).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,58 @@
+# Roadmap
+
+Audit of `ucsc-custom-functionality` @ 2.0.6. Ordered by severity. Items marked **verified** were reproduced locally; others are read-confirmed risks.
+
+## P0 — Broken now
+
+| # | Item | Location |
+|---|---|---|
+| 1 | **Magazine block never registers.** Constant points at `/build/views/magazine-block`; webpack emits `build/views/magazine-lock` (it mirrors the *source dir*, not the block slug). `register_block_type_from_metadata()` gets a missing `block.json`. Fix: rename `src/views/magazine-lock` → `magazine-block`. **verified** | [Core.php:37](src/Core.php#L37) |
+| 2 | **`composer lint` cannot run.** Ruleset declares no `<file>`; phpcs exits `You must supply at least one file or directory`. Add `<file>plugin.php</file>`, `<file>lib</file>`, `<file>src</file>`. **verified** | [.phpcs.xml.dist](.phpcs.xml.dist) |
+| 3 | **phpcs fatals when given paths.** WPCS 2.3.0 × PHPCS 3.13.5 on PHP 8.5 → `TypeError` in `ControlStructureSpacingSniff`. Upgrade to `wp-coding-standards/wpcs:^3.1` + `phpcsstandards/phpcsextra`. No PHP linting has run in a long time. **verified** | [composer.json](composer.json) |
+| 4 | **`npm run lint` only lints CSS.** `npm run lint:css lint:js` passes `lint:js` as an *argument* to lint:css, not a second script. Use `npm run lint:css && npm run lint:js`. **verified** | [package.json](package.json) |
+
+## P1 — Correctness & security
+
+| # | Item | Location |
+|---|---|---|
+| 5 | **Unsanitized `$_POST` into outbound URL path.** `$_POST['taxonomy_selected']` is read with no `isset`/`wp_unslash`/sanitize, then concatenated into the news REST path. Editor-controlled path traversal on the outbound request + transient-key poisoning. Auth is inherited from ACF's AJAX handler, so scope is authenticated editors. Whitelist against `News_Block::ALLOWED_TAX`. | [News_Blocks_Hooks.php:83](src/Hooks/News_Blocks_Hooks.php#L83), [:122](src/Hooks/News_Blocks_Hooks.php#L122) |
+| 6 | Same unguarded `$_POST` read into `get_terms()`. Lower impact (WP validates taxonomy) but same missing guards. | [Taxonomies_Hooks.php:89](src/Hooks/Taxonomies_Hooks.php#L89) |
+| 7 | **Fatal risk:** `in_array( 'embed-post', $query['slug__in'] )` — index unguarded; `get_block_templates` callers frequently omit `slug__in` → `TypeError` on PHP 8. | [Post_Single.php:16](src/Template/Post_Single.php#L16) |
+| 8 | **Fatal risk:** `get_current_screen()` may return `null`; `->base` dereferenced unguarded. | [plugin.php:60](plugin.php#L60) |
+| 9 | Unguarded index `$this->query_loop[ MANUAL_CARDS ]` in manual query mode. | [Query_Loop_Controller.php](src/Components/Query_Loop_Controller.php) |
+| 10 | **Yoast integration is a no-op loop.** Iterates `PRIMARY_TAX_SUPPORT` (5 taxonomies) but `$tax` is never used — only `academics` is ever registered. **verified** | [Integrations_Subscriber.php:17-26](src/Integrations/Integrations_Subscriber.php#L17-L26) |
+| 11 | `esc_html__( '', 'ucsc' )` — translating the empty string returns the PO file's metadata header, not `''`. **verified** | [Query_Loop.php:102](src/Blocks/Query_Loop.php#L102) |
+| 12 | **Duplicate script handle.** `Assets_Enqueuer` loops every registered UCSC block but enqueues each script under the same constant handle (`index`); only the first block's JS loads. Styles are correctly suffixed per block. **verified** | [Assets_Enqueuer.php](src/Assets/Assets_Enqueuer.php) |
+| 13 | `(int) get_field('posts_per_page') ?? self::PER_PAGE` — `??` is dead (a cast never yields null). Missing field → `0` → `array_slice(…, 0, 0)` → empty block. Affects blocks inserted before the field existed. | [News_Block_Controller.php:42](src/Components/News_Block_Controller.php#L42) |
+
+## P2 — Performance & lifecycle
+
+| # | Item | Location |
+|---|---|---|
+| 14 | **N+1 blocking HTTP on cold render.** One `wp_remote_get` per featured image *plus* one per coauthor, on top of the posts request — up to ~19 sequential calls for a 9-post block. Batch via `_embed` on the posts request. **verified** | [News_Block_Controller.php:132-190](src/Components/News_Block_Controller.php#L132-L190) |
+| 15 | **No `timeout` on any remote request** — defaults to 5s each, so #14 can stall a page render for tens of seconds. Set an explicit short timeout. | [News_Request.php:17](src/Request/News_Request.php#L17) |
+| 16 | **Cache keys embed `taxonomy_ids`,** so the same media/coauthor is cached separately per block configuration. Key those by object ID only. **verified** | [News_Block_Controller.php:125-130](src/Components/News_Block_Controller.php#L125-L130) |
+| 17 | **No activation/deactivation/uninstall hooks at all.** CPT registers a `photo-of-the-week` rewrite with no flush (404s until permalinks are re-saved); `wp_template` posts are created but never removed; transients never cleaned. **verified** | plugin-wide |
+| 18 | Custom templates are bound to the `wp_theme` term `ucsc-2022`. Theme rename/switch orphans them silently. | [Template.php:14](src/Template/Template.php#L14) |
+| 19 | `News_Request::request()` recurses over paginated results with no page cap. A large `X-WP-TotalPages` means unbounded sequential fetches. | [News_Request.php:30-40](src/Request/News_Request.php#L30-L40) |
+
+## P3 — Tooling, packaging, docs
+
+| # | Item | Location |
+|---|---|---|
+| 20 | **Declared PHP floor is wrong.** Code uses union types (`array|string`), so the real minimum is PHP 8.0; CONTRIBUTING says 7.4+, phpcs is configured for WP 4.9. Add `Requires PHP: 8.0` / `Requires at least:` headers and align the docs. | [News_Block_Controller.php:27](src/Components/News_Block_Controller.php#L27), [plugin.php](plugin.php) |
+| 21 | **Text domain `ucsc` is never loaded** and there is no `Text Domain:`/`Domain Path:` header. All `__()` calls are untranslatable. | [plugin.php](plugin.php) |
+| 22 | Settings page hardcodes `WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php'`; breaks if the directory is renamed. Use `plugin_dir_path()` / a constant. | [settings.php:42](lib/functions/settings.php#L42) |
+| 23 | **No CI lint gate.** `release.yml` only builds on tag push. Add a PR workflow running phpcs + both JS/CSS linters (after P0-2/3/4 land). | [.github/workflows/](.github/workflows/) |
+| 24 | No test suite. Nothing enforces the block-registration path contract that broke #1 — a smoke test asserting every `Core::BLOCKS_*` path resolves to a real `block.json` would have caught it. | — |
+| 25 | `echo _e( … )` — redundant (`_e` already echoes). Harmless, phpcs-flagged. | [news-block/index.php:37](src/views/news-block/index.php#L37) |
+| 26 | Legacy `lib/functions/` and namespaced `src/` maintain two parallel conventions. Consider folding the procedural files behind a loader registered from `Core`, keeping the `ucsc_` prefix contract. | [lib/functions/](lib/functions/) |
+| 27 | GTM container ID and SiteImprove script ID are hardcoded; no per-site override. | [ga.php](lib/functions/scripts/ga.php), [site-improve.php](lib/functions/scripts/site-improve.php) |
+
+## Suggested sequence
+
+1. **Unblock quality gates** — #2, #3, #4. Nothing else is safely verifiable until linting runs.
+2. **Ship the visible fix** — #1, plus #12 (both are "the block doesn't work" bugs).
+3. **Harden** — #5, #6, #7, #8, #9.
+4. **Lifecycle** — #17, then #14/#15/#16 as one caching pass.
+5. **Gate it** — #23, #24, so P0 regressions can't recur.


### PR DESCRIPTION
## What does this do/fix?

Adds two documentation files. No plugin code changes.

**`CLAUDE.md`** — repo guidance for Claude Code sessions. Covers the parts of the architecture that require reading several files to understand:

- the ACF block triad (`src/Blocks/` field group + `src/Components/` controller + `src/views/` template) and the `{group}_{name}` field-key composition the `acf/…/key=` filters depend on
- `Core::render_template()` rewriting `build/views/` back to `src/views/`, so PHP view edits are live but JS/SCSS need a build
- the directory-name coupling between `src/views/`, webpack output, and `Core::BLOCKS_*`
- the News block being the one block that fetches over REST from the news site, keyed off `wp_get_environment_type()`
- `UCSC_NEWS_SITE` / ACF gating, and that there is no test suite

**`ROADMAP.md`** — audit of the plugin at 2.0.6. 27 items in four tiers with file references and a suggested sequence.

Highlights:

- **P0:** the Magazine block never registers (`Core::BLOCKS_NEWS_ONLY` points at `build/views/magazine-block`, webpack emits `magazine-lock`); `composer lint` cannot run (ruleset declares no `<file>`); phpcs fatals when given paths (WPCS 2.3.0 × PHPCS 3.13.5 on PHP 8.5); `npm run lint` silently skips JS.
- **P1:** unsanitized `$_POST['taxonomy_selected']` concatenated into an outbound REST path; two unguarded dereferences that fatal on PHP 8; the Yoast integration loop never uses its loop variable; duplicate script handle means only the first block's JS enqueues.
- **P2:** N+1 blocking HTTP with no timeout on News block renders; no activation/deactivation/uninstall hooks anywhere.

Items marked **verified** were reproduced locally; the rest are read-confirmed from source and worth a runtime check before acting.

## Tests

Docs only — no runtime behavior changes, nothing to smoke-test.

To sanity-check the two reproducible P0 findings:

```bash
npm run build && ls build/views    # emits magazine-lock, not magazine-block
composer lint                      # errors: "You must supply at least one file or directory"
npm run lint                       # runs lint:css only; passes "lint:js" as a glob arg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)