### PR TITLE
fix: restore working phpcs and npm lint gates

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -3,6 +3,24 @@
 
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 
+	<!--
+	Files and directories to scan when phpcs is run with no path argument.
+	Without these, phpcs exits with "You must supply at least one file or
+	directory to process."
+	-->
+	<file>plugin.php</file>
+	<file>lib</file>
+	<file>src</file>
+
+	<!--
+	Only sniff PHP. WPCS 3.x dropped its JavaScript sniffs, so scanning .js
+	here produces meaningless noise; eslint owns those files.
+	-->
+	<arg name="extensions" value="php"/>
+
+	<!-- Report paths relative to the project root rather than absolute. -->
+	<arg name="basepath" value="."/>
+
 	<!-- Exclude WP Core folders and files from being checked. -->
 	<exclude-pattern>/docroot/wp-admin/*</exclude-pattern>
 	<exclude-pattern>/docroot/wp-includes/*</exclude-pattern>
@@ -38,6 +56,25 @@
 		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
+	</rule>
+
+	<!--
+	src/ is PSR-4 (UCSC\Blocks\) and is autoloaded by class name, so its files
+	are named Foo_Block.php, not class-foo-block.php. The WordPress file-naming
+	convention cannot be satisfied there without breaking the autoloader.
+	lib/ does follow WP naming and stays fully checked.
+	-->
+	<rule ref="WordPress.Files.FileName">
+		<exclude-pattern>/src/*</exclude-pattern>
+	</rule>
+
+	<!--
+	src/ targets PHP 8.0+ (declare(strict_types=1), union types) and uses short
+	array syntax throughout, by convention. Enforcing long arrays there would
+	rewrite ~280 literals to no benefit. lib/ stays fully checked.
+	-->
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax">
+		<exclude-pattern>/src/*</exclude-pattern>
 	</rule>
 
 	<!-- Let's also check that everything is properly documented. -->

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "UCSC Custom Functionality WordPress Plugin",
     "license": "GPL-2.0-or-later",
     "require-dev": {
-        "wp-coding-standards/wpcs": "^2.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2"
+        "wp-coding-standards/wpcs": "^3.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
     },
     "scripts": {
         "lint": "./vendor/bin/phpcs",
-        "lint-fix": "./vendor/bin/phpcbf --extensions=php ."
+        "lint-fix": "./vendor/bin/phpcbf"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,40 +4,43 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55ad500a7aa601402d9947e2b921f6d5",
+    "content-hash": "710cf8e439e460d15a75a865590af855",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -47,17 +50,16 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -77,23 +79,217 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T11:13:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -159,34 +355,42 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -203,6 +407,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -210,7 +415,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-27T11:53:23+00:00"
         }
     ],
     "aliases": [],

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
     "scripts": {
         "build": "wp-scripts build",
         "dev": "wp-scripts start",
-        "lint:css": "wp-scripts lint-style 'src/**/*.scss' --fix",
-        "lint:js": "wp-scripts lint-js 'src/**/*.js' --fix",
-        "lint": "npm run lint:css lint:js",
+        "lint:css": "wp-scripts lint-style 'src/**/*.scss'",
+        "lint:js": "wp-scripts lint-js 'src/**/*.js'",
+        "lint:css:fix": "wp-scripts lint-style 'src/**/*.scss' --fix",
+        "lint:js:fix": "wp-scripts lint-js 'src/**/*.js' --fix",
+        "lint": "npm run lint:css && npm run lint:js",
+        "lint:fix": "npm run lint:css:fix && npm run lint:js:fix",
         "release": "commit-and-tag-version",
         "zip": "wp-scripts plugin-zip",
         "packages-update": "wp-scripts packages-update"


### PR DESCRIPTION
## What does this do/fix?

Fixes #101. Three separate faults each blocked PHP linting; all are fixed here. No PHP linting had run against this repo in a long time.

### The three blockers

**1. `composer lint` could not run at all.** `.phpcs.xml.dist` declared no `<file>` elements, so a bare `phpcs` exited with `You must supply at least one file or directory to process.` Adds `plugin.php`, `lib`, `src`.

**2. phpcs fataled when given real paths.** WPCS 2.3.0 on PHP 8.5 threw a `TypeError` in `ControlStructureSpacingSniff`:

```
PHP Fatal error: Uncaught TypeError: vsprintf(): Argument #2 ($values) must be of type array, string given
  #3 wpcs/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php(391)
```

Upgrades `wp-coding-standards/wpcs` to `^3.1` (resolves to **3.4.1**) and `dealerdirect/phpcodesniffer-composer-installer` to `^1.0`, which pull in `phpcsstandards/phpcsutils` and `phpcsstandards/phpcsextra` transitively. (The issue suggested requiring PHPCSExtra directly; it arrives as a WPCS 3.x dependency and the ruleset references no PHPCSExtra sniff by name, so a direct constraint would be redundant.)

**3. `npm run lint` only linted CSS.** `"npm run lint:css lint:js"` passes `lint:js` as an *argument* to `lint:css`. Now `&&`-chained.

### Supporting changes

- **`--extensions=php`.** WPCS 3.x dropped its JavaScript sniffs, so phpcs was scanning `.js` and producing **248 meaningless errors**. eslint owns those files.
- **`basepath`** so violations report relative to the project root instead of absolute paths.
- **Split the JS/CSS lint scripts into check and fix variants.** Both previously had `--fix` baked in, which makes them unusable as a gate and silently rewrites files in CI. Now mirrors the existing `composer lint` / `lint-fix` split:

  | | check | fix |
  |---|---|---|
  | PHP | `composer lint` | `composer lint-fix` |
  | JS | `npm run lint:js` | `npm run lint:js:fix` |
  | CSS | `npm run lint:css` | `npm run lint:css:fix` |
  | all | `npm run lint` | `npm run lint:fix` |

- **Dropped `--extensions=php .` from `composer lint-fix`.** With the ruleset now declaring its own scope, that explicit path override made phpcbf sweep `build/` too.

### Two intentionally scoped-off sniffs

These contradict the codebase's deliberate architecture and can never be satisfied in `src/`:

| Sniff | Count | Why |
|---|---|---|
| `WordPress.Files.FileName` | 93 | `src/` is PSR-4 (`UCSC\Blocks\`), autoloaded by class name — `Foo_Block.php`, not `class-foo-block.php`. Satisfying this would break the autoloader. |
| `Universal.Arrays.DisallowShortArraySyntax` | 282 | `src/` targets PHP 8.0+ and uses `[]` throughout by convention. Enforcing `array()` would rewrite ~280 literals to no benefit. |

Both are **scoped to `src/` only** via `<exclude-pattern>`, not disabled — they remain fully enforced on `lib/`, which violates neither. Verified: both sniffs are still registered in the standard (`phpcs -e`), and all 375 violations were confined to `src/` to begin with.

### What this PR does *not* do

The linters now report a **real backlog instead of crashing**: 1345 phpcs errors / 31 warnings, and 135 eslint errors. That is deferred to **#116** rather than fixed here — clearing it mechanically touches ~65 files and would collide with every open branch. This satisfies the "explicitly deferred with a follow-up issue" acceptance criterion on #101.

⚠️ **`composer lint` and `npm run lint` therefore exit non-zero on this branch.** That is the intended end state: they are reporting findings, where before they crashed or silently did nothing. #111 should run the gate in report-only mode until #116 lands.

## Tests

```bash
composer install    # picks up WPCS 3.4.1
npm install
composer lint
npm run lint
npm run build
```

Verified locally on PHP 8.5.4 / Node 20.18.0:

| Check | Before | After |
|---|---|---|
| `composer lint` | `ERROR: You must supply at least one file or directory` (exit 3) | runs to completion, 1345 errors / 31 warnings in 68 files (exit 2) |
| `phpcs plugin.php lib src` | `PHP Fatal error: Uncaught TypeError` (exit 255) | no fatal |
| `composer lint-fix` | — | fixes 812 errors across 65 files (reverted after testing) |
| `npm run lint` | ran stylelint only | runs stylelint **and** eslint |
| `npm run build` | green | green |

Reviewer checks:

- [ ] `composer lint` completes without a fatal and reports a violation summary
- [ ] `composer lint-fix` applies fixes and touches nothing outside `plugin.php`, `lib/`, `src/`
- [ ] `npm run lint` visibly invokes both `lint:css` and `lint:js`
- [ ] `npm run lint:js` no longer modifies files (no `--fix`)
- [ ] `git diff` after running the check-only scripts is empty

Note: `composer lint-fix` exits `1` when it has applied fixes — normal phpcbf behavior, not a failure.
