### PR TITLE
style: apply phpcbf mechanical formatting fixes (1345 -> 550 errors)

### DIFF
--- a/lib/functions/admin-menus.php
+++ b/lib/functions/admin-menus.php
@@ -22,12 +22,9 @@ if ( ! function_exists( 'ucsc_custom_functionality_customize_dash' ) ) {
 	 * @author UC Santa Cruz
 	 * @license GNU General Public License 2.0+
 	 */
-
-
 	function ucsc_custom_functionality_customize_dash() {
 
 		remove_menu_page( 'link-manager.php' );
-
 	}
 }
 add_action( 'admin_menu', 'ucsc_custom_functionality_customize_dash' );
@@ -36,16 +33,16 @@ add_action( 'admin_menu', 'ucsc_custom_functionality_customize_dash' );
 if ( ! function_exists( 'ucsc_custom_functionality_remove_from_admin_bar' ) ) {
 
 	/**
-	* Remove items from Admin Bar
-	*
-	* @param mixed $wp_admin_bar
-	* @return void
-	* Removes unwanted items from the WP Admin bar
-	* @package
-	* @since
-	* @author UC Santa Cruz
-	* @license GNU General Public License 2.0+
-	*/
+	 * Remove items from Admin Bar
+	 *
+	 * @param mixed $wp_admin_bar
+	 * @return void
+	 * Removes unwanted items from the WP Admin bar
+	 * @package
+	 * @since
+	 * @author UC Santa Cruz
+	 * @license GNU General Public License 2.0+
+	 */
 	function ucsc_custom_functionality_remove_from_admin_bar( $wp_admin_bar ) {
 		if ( ! current_user_can( 'edit_themes' ) ) {
 			$wp_admin_bar->remove_node( 'customize' );
@@ -56,16 +53,15 @@ add_action( 'admin_bar_menu', 'ucsc_custom_functionality_remove_from_admin_bar',
 
 if ( ! function_exists( 'ucsc_custom_functionality_remove_from_dash_panel' ) ) {
 	/**
-	* Remove items from Dashboard panel
-	*
-	* @return void
-	* Remove left-hand dashboard items
-	* @package
-	* @since
-	* @author UC Santa Cruz
-	* @license GNU General Public License 2.0+
-	*/
-
+	 * Remove items from Dashboard panel
+	 *
+	 * @return void
+	 * Remove left-hand dashboard items
+	 * @package
+	 * @since
+	 * @author UC Santa Cruz
+	 * @license GNU General Public License 2.0+
+	 */
 	function ucsc_custom_functionality_remove_from_dash_panel() {
 		global $submenu;
 		foreach ( $submenu as $name => $items ) {

--- a/lib/functions/scripts.php
+++ b/lib/functions/scripts.php
@@ -33,14 +33,13 @@ if ( file_exists( UCSC_DIR . '/lib/functions/scripts/site-improve.php' ) ) {
  * @author UCSC
  * @link  https://developer.wordpress.org/news/2024/08/how-to-extend-a-wordpress-block/#adding-custom-functionality
  */
-function ucsc_cf_enqueue_block_variations()
-{
-    wp_enqueue_script(
-        'ucsc-cf-enqueue-block-variations',
-        UCSC_PLUGIN_URL . 'assets/js/variations.js',
-        array('wp-blocks', 'wp-dom-ready'),
-        wp_get_theme()->get('Version'),
-        false
-    );
+function ucsc_cf_enqueue_block_variations() {
+	wp_enqueue_script(
+		'ucsc-cf-enqueue-block-variations',
+		UCSC_PLUGIN_URL . 'assets/js/variations.js',
+		array( 'wp-blocks', 'wp-dom-ready' ),
+		wp_get_theme()->get( 'Version' ),
+		false
+	);
 }
-add_action('enqueue_block_editor_assets', 'ucsc_cf_enqueue_block_variations');
+add_action( 'enqueue_block_editor_assets', 'ucsc_cf_enqueue_block_variations' );

--- a/lib/functions/scripts/ga.php
+++ b/lib/functions/scripts/ga.php
@@ -11,7 +11,8 @@ add_action( 'wp_head', 'ucsc_google_tag_manager_head', 1 );
 
 add_action( 'wp_body_open', 'ucsc_google_tag_manager_body' );
 
-function ucsc_google_tag_manager_head() {   ?>
+function ucsc_google_tag_manager_head() {
+	?>
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -24,10 +25,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 function ucsc_google_tag_manager_body() {
 	?>
-  <!-- Google Tag Manager (noscript) -->
+	<!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5RFHNC"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 	<?php
-
 }

--- a/lib/functions/scripts/site-improve.php
+++ b/lib/functions/scripts/site-improve.php
@@ -7,7 +7,8 @@
 
 add_action( 'wp_footer', 'ucsc_site_improve_analytics' );
 
-function ucsc_site_improve_analytics() {    ?>
+function ucsc_site_improve_analytics() {
+	?>
 <!-- Siteimprove -->
 <script type="text/javascript">
 /*<![CDATA[*/

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -14,52 +14,49 @@
 
 /** Register new menu and page */
 
-if (! function_exists('ucsc_add_settings_page')) {
-    function ucsc_add_settings_page()
-    {
-        add_options_page('UCSC Custom Functionality plugin page', 'UCSC Custom Functionality', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page');
-    }
+if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
+	function ucsc_add_settings_page() {
+		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
+	}
 }
-add_action('admin_menu', 'ucsc_add_settings_page');
+add_action( 'admin_menu', 'ucsc_add_settings_page' );
 
 
 /**
- * HTML output of Settings page 
+ * HTML output of Settings page
  *
- * note: This page typically displays a form for displaying any settings options. 
+ * note: This page typically displays a form for displaying any settings options.
  * It is not needed at this point.
  * https://developer.wordpress.org/plugins/settings/custom-settings-page/
- *
  */
 
-if (! function_exists('ucsc_render_plugin_settings_page')) {
-    function ucsc_render_plugin_settings_page()
-    {
-        if (! current_user_can('manage_options')) {
-            return;
-        }
+if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
+	function ucsc_render_plugin_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-        $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php');
-    ?>
-        <div class="wrap cf-admin-settings-page">
-            <h1><?php echo esc_html($plugin_data['Name']); ?></h1>
-            <h2>Version: <?php echo esc_html($plugin_data['Version']); ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
-            <p><?php echo wp_kses_post($plugin_data['Description']); ?></p>
-            <hr>
-            <h3>Features added by this plugin:</h3>
-            <ul>
-                <li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
-                <li><strong>Shortcodes:</strong>
-                    <ul>
-                        <li><code>[site-search]</code>: Inserts the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
-                        <li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode('[copyright]') ?>)</li>
-                        <li><code>[last-modified]</code>: Displays the <i>last modified</i> date of a page</li>
-                    </ul>
-                </li>
-            </ul>
-            <hr>
-            <p>XML-RPC is disabled by this plugin for security. See <a href="https://docs.pantheon.io/guides/wordpress-developer/xml-rpc-attacks" rel="noopener noreferrer">Pantheon&rsquo;s guidance on XML-RPC attacks</a>.</p>
-        </div>
-<?php
-    }
+		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-custom-functionality/plugin.php' );
+		?>
+		<div class="wrap cf-admin-settings-page">
+			<h1><?php echo esc_html( $plugin_data['Name'] ); ?></h1>
+			<h2>Version: <?php echo esc_html( $plugin_data['Version'] ); ?> <a href="https://github.com/ucsc/ucsc-custom-functionality/releases">(release notes)</a></h2>
+			<p><?php echo wp_kses_post( $plugin_data['Description'] ); ?></p>
+			<hr>
+			<h3>Features added by this plugin:</h3>
+			<ul>
+				<li><strong>Google Analytics 4</strong> and <strong>Site Improve</strong> scripts to site footer</li>
+				<li><strong>Shortcodes:</strong>
+					<ul>
+						<li><code>[site-search]</code>: Inserts the HTML script tag to display <strong>Google Site Search</strong> results on a page</li>
+						<li><code>[copyright]</code>: Displays copyright symbol and year (<?php echo do_shortcode( '[copyright]' ); ?>)</li>
+						<li><code>[last-modified]</code>: Displays the <i>last modified</i> date of a page</li>
+					</ul>
+				</li>
+			</ul>
+			<hr>
+			<p>XML-RPC is disabled by this plugin for security. See <a href="https://docs.pantheon.io/guides/wordpress-developer/xml-rpc-attacks" rel="noopener noreferrer">Pantheon&rsquo;s guidance on XML-RPC attacks</a>.</p>
+		</div>
+		<?php
+	}
 }

--- a/lib/functions/shortcodes.php
+++ b/lib/functions/shortcodes.php
@@ -13,29 +13,31 @@
 
 if ( ! function_exists( 'ucsc_custom_functionality_google_search' ) ) {
 	/**
-	* Google Site Search: [site-search]
-	* returns the HTML script tag and properly configured <div> element
-	* to display site search results on a WordPress page
-	*/
+	 * Google Site Search: [site-search]
+	 * returns the HTML script tag and properly configured <div> element
+	 * to display site search results on a WordPress page
+	 */
 	function ucsc_custom_functionality_google_search() {
 
 		// Configuration params to be added to the output string
-		$script_source = "https://cse.google.com/cse.js?cx=012090462228956765947:d0ywvq7bxee";
-		$site_url = parse_url( get_site_url(), PHP_URL_HOST );
-		
+		$script_source = 'https://cse.google.com/cse.js?cx=012090462228956765947:d0ywvq7bxee';
+		$site_url      = parse_url( get_site_url(), PHP_URL_HOST );
+
+		// phpcs:disable WordPress.WP.CapitalPDangit -- lowercase hostname fragments matched case-sensitively, not the product name.
 		/**
-		* Search ucsc.edu if the site is in development:
-		*  1. domain contains .wordpress or .wordpress-dev
-		*  2. domain contains .local (which captures .localhost too)
-		*/ 
-		if (preg_match("/\.wordpress(\-dev)?|\.local/usmx", $site_url)) {
+		 * Search ucsc.edu if the site is in development:
+		 *  1. domain contains .wordpress or .wordpress-dev
+		 *  2. domain contains .local (which captures .localhost too)
+		 */
+		if ( preg_match( '/\.wordpress(\-dev)?|\.local/usmx', $site_url ) ) {
 			$search_url = 'ucsc.edu';
 		} else {
 			$search_url = $site_url;
 		}
-		
+		// phpcs:enable WordPress.WP.CapitalPDangit
+
 		// Return the configured string for Google Search results to display on the page
-		return sprintf('<script async src="%s"></script><div class="gcse-searchresults-only" data-queryParameterName="s" data-as_sitesearch="%s"></div>', $script_source, $search_url);
+		return sprintf( '<script async src="%s"></script><div class="gcse-searchresults-only" data-queryParameterName="s" data-as_sitesearch="%s"></div>', $script_source, $search_url );
 	}
 }
 add_shortcode( 'site-search', 'ucsc_custom_functionality_google_search' );

--- a/plugin.php
+++ b/plugin.php
@@ -12,7 +12,7 @@
  */
 
 // Set plugin directory.
-define( 'UCSC_DIR', dirname( __FILE__ ) );
+define( 'UCSC_DIR', __DIR__ );
 define( 'UCSC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 // Include Customization files.
@@ -43,22 +43,21 @@ if ( file_exists( UCSC_DIR . '/lib/functions/settings.php' ) ) {
 
 if ( ! function_exists( 'ucsc_enqueue_admin_styles' ) ) {
 	/**
-	* Enqueue admin settings styles
-	*
-	* No styles are enqueued for raw HTML in setting panel.
-	* In order to output HTML in the settings panel we need some basic styles.
-	*
-	* @since 1.7.0
+	 * Enqueue admin settings styles
+	 *
+	 * No styles are enqueued for raw HTML in setting panel.
+	 * In order to output HTML in the settings panel we need some basic styles.
+	 *
+	 * @since 1.7.0
 	 *
 	 * @author UCSC
 	 *
 	 * @link https://developer.wordpress.org/reference/hooks/admin_enqueue_scripts/#Example:_Load_CSS_File_from_a_plugin_on_specific_Admin_Page
 	 */
-
-	function ucsc_enqueue_admin_styles($hook): void {
+	function ucsc_enqueue_admin_styles( $hook ): void {
 		$settings_css   = plugin_dir_url( __FILE__ ) . 'lib/css/admin-settings.css';
 		$current_screen = get_current_screen();
-		// Check if it's "?page=ucsc-custom-functionality-settings." If not, just empty return. 
+		// Check if it's "?page=ucsc-custom-functionality-settings." If not, just empty return.
 		if ( strpos( $current_screen->base, 'ucsc-custom-functionality-settings' ) === false ) {
 			return;
 		}
@@ -70,10 +69,15 @@ if ( ! function_exists( 'ucsc_enqueue_admin_styles' ) ) {
 }
 add_action( 'admin_enqueue_scripts', 'ucsc_enqueue_admin_styles' );
 
-add_action( 'plugins_loaded', static function (): void {
-	if ( ! function_exists( 'acf_add_local_field_group' ) ) {
-		return;
-	}
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+			return;
+		}
 
-	\UCSC\Blocks\Core::instance()->init();
-}, 100, 0 );
+		\UCSC\Blocks\Core::instance()->init();
+	},
+	100,
+	0
+);

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -4,7 +4,7 @@ namespace UCSC\Blocks\Assets;
 
 trait Assets {
 
-	public function get_asset_file_args(string $file_path): array {
+	public function get_asset_file_args( string $file_path ): array {
 		if ( ! file_exists( $file_path ) ) {
 			return [];
 		}
@@ -12,5 +12,4 @@ trait Assets {
 
 		return is_array( $args ) ? $args : [];
 	}
-
 }

--- a/src/Assets/Assets_Enqueuer.php
+++ b/src/Assets/Assets_Enqueuer.php
@@ -15,20 +15,23 @@ class Assets_Enqueuer {
 	}
 
 	public function register( string $assets_file, string $handle_file, string $css_handle ): void {
-		$ucsc_custom_blocks = array_filter( \WP_Block_Type_Registry::get_instance()->get_all_registered(), static function ( $block ) {
-			return stripos( $block->name, 'ucsc-custom-functionality/' ) !== false;
-		} );
+		$ucsc_custom_blocks = array_filter(
+			\WP_Block_Type_Registry::get_instance()->get_all_registered(),
+			static function ( $block ) {
+				return stripos( $block->name, 'ucsc-custom-functionality/' ) !== false;
+			}
+		);
 
 		if ( empty( $ucsc_custom_blocks ) ) {
 			return;
 		}
-		
+
 		foreach ( $ucsc_custom_blocks as $block ) {
 			$parts      = explode( '/', $block->name );
 			$block_name = end( $parts );
 
-			$args = $this->get_asset_file_args( $this->assets_path . $block_name . '/' .$assets_file );
-			
+			$args = $this->get_asset_file_args( $this->assets_path . $block_name . '/' . $assets_file );
+
 			wp_enqueue_style(
 				$css_handle . '-' . $block_name,
 				$this->assets_path_uri . $block_name . '/' . $css_handle . '.css',
@@ -46,5 +49,4 @@ class Assets_Enqueuer {
 			);
 		}
 	}
-
 }

--- a/src/Assets/Assets_Subscriber.php
+++ b/src/Assets/Assets_Subscriber.php
@@ -5,27 +5,47 @@ namespace UCSC\Blocks\Assets;
 class Assets_Subscriber {
 
 	public function register(): void {
-		add_action( 'wp_enqueue_scripts', static function (): void {
-			( new Public_Assets_Enqueuer() )->register( Public_Assets_Enqueuer::ASSETS_FILE, Public_Assets_Enqueuer::PUBLIC, Public_Assets_Enqueuer::PUBLIC_CSS );
-		}, 10, 0 );
+		add_action(
+			'wp_enqueue_scripts',
+			static function (): void {
+				( new Public_Assets_Enqueuer() )->register( Public_Assets_Enqueuer::ASSETS_FILE, Public_Assets_Enqueuer::PUBLIC, Public_Assets_Enqueuer::PUBLIC_CSS );
+			},
+			10,
+			0
+		);
 
-		add_action( 'admin_enqueue_scripts', static function (): void {
-			( new Public_Assets_Enqueuer() )->register( Public_Assets_Enqueuer::ASSETS_FILE, Public_Assets_Enqueuer::PUBLIC, Public_Assets_Enqueuer::PUBLIC_CSS );
-		}, 10, 0 );
+		add_action(
+			'admin_enqueue_scripts',
+			static function (): void {
+				( new Public_Assets_Enqueuer() )->register( Public_Assets_Enqueuer::ASSETS_FILE, Public_Assets_Enqueuer::PUBLIC, Public_Assets_Enqueuer::PUBLIC_CSS );
+			},
+			10,
+			0
+		);
 
-		add_action( 'enqueue_block_editor_assets', static function (): void {
-			( new Editor_Assets_Enqueuer() )->register( Editor_Assets_Enqueuer::ASSETS_FILE, Editor_Assets_Enqueuer::EDITOR, Editor_Assets_Enqueuer::EDITOR );
-		}, 10, 0 );
+		add_action(
+			'enqueue_block_editor_assets',
+			static function (): void {
+				( new Editor_Assets_Enqueuer() )->register( Editor_Assets_Enqueuer::ASSETS_FILE, Editor_Assets_Enqueuer::EDITOR, Editor_Assets_Enqueuer::EDITOR );
+			},
+			10,
+			0
+		);
 
-		wp_enqueue_block_style( 'core/post-terms', [
-			'handle' => 'ucsc-custom-functionality-post-terms',
-			'src'    => trailingslashit( UCSC_PLUGIN_URL ) . 'build/css/post-terms.css',
-		]);
+		wp_enqueue_block_style(
+			'core/post-terms',
+			[
+				'handle' => 'ucsc-custom-functionality-post-terms',
+				'src'    => trailingslashit( UCSC_PLUGIN_URL ) . 'build/css/post-terms.css',
+			]
+		);
 
-		wp_enqueue_block_style( 'outermost/social-sharing', [
-			'handle' => 'ucsc-custom-functionality-social-sharing',
-			'src'    => trailingslashit( UCSC_PLUGIN_URL ) . 'build/css/social-sharing.css',
-		]);
+		wp_enqueue_block_style(
+			'outermost/social-sharing',
+			[
+				'handle' => 'ucsc-custom-functionality-social-sharing',
+				'src'    => trailingslashit( UCSC_PLUGIN_URL ) . 'build/css/social-sharing.css',
+			]
+		);
 	}
-
 }

--- a/src/Assets/Editor_Assets_Enqueuer.php
+++ b/src/Assets/Editor_Assets_Enqueuer.php
@@ -7,5 +7,4 @@ class Editor_Assets_Enqueuer extends Assets_Enqueuer {
 	public const EDITOR           = 'index';
 	public const EDITOR_FILE_NAME = 'index';
 	public const ASSETS_FILE      = self::EDITOR_FILE_NAME . '.asset.php';
-
 }

--- a/src/Assets/Public_Assets_Enqueuer.php
+++ b/src/Assets/Public_Assets_Enqueuer.php
@@ -7,5 +7,4 @@ class Public_Assets_Enqueuer extends Assets_Enqueuer {
 	public const PUBLIC      = 'index';
 	public const PUBLIC_CSS  = 'style-index';
 	public const ASSETS_FILE = self::PUBLIC . '.asset.php';
-
 }

--- a/src/Blocks/ACF_Group.php
+++ b/src/Blocks/ACF_Group.php
@@ -5,7 +5,7 @@ namespace UCSC\Blocks\Blocks;
 use UCSC\Blocks\Traits\With_Get_Field_Key;
 
 abstract class ACF_Group {
-	
+
 	use With_Get_Field_Key;
 
 	public bool $enabled = true;
@@ -22,7 +22,7 @@ abstract class ACF_Group {
 		if ( ! $this->enabled ) {
 			return;
 		}
-		
+
 		acf_add_local_field_group( $this->get_group_args() );
 	}
 
@@ -40,5 +40,4 @@ abstract class ACF_Group {
 			'location'              => $this->get_locations(),
 		];
 	}
-	
 }

--- a/src/Blocks/Contracts/CTA_Field.php
+++ b/src/Blocks/Contracts/CTA_Field.php
@@ -3,9 +3,8 @@
 namespace UCSC\Blocks\Blocks\Contracts;
 
 interface CTA_Field {
-	
-	public const CTA = 'cta';
-	
-	public function get_cta_field( string $group_name, string $label, string $name = '' ): array;
 
+	public const CTA = 'cta';
+
+	public function get_cta_field( string $group_name, string $label, string $name = '' ): array;
 }

--- a/src/Blocks/Contracts/Taxonomies.php
+++ b/src/Blocks/Contracts/Taxonomies.php
@@ -10,5 +10,4 @@ interface Taxonomies {
 	public function get_taxonomies_list( string $name ): array;
 
 	public function get_taxonomies_items( string $name ): array;
-	
 }

--- a/src/Blocks/Featured_News_Block.php
+++ b/src/Blocks/Featured_News_Block.php
@@ -6,15 +6,15 @@ use UCSC\Blocks\Blocks\Contracts\CTA_Field;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
 class Featured_News_Block extends Query_Loop implements CTA_Field {
-    
-    use With_CTA_Field;
+
+	use With_CTA_Field;
 
 	public const NAME = 'ucsc_featured_news_block';
 
-    public const CTA_FIELD = 'featured_cta';
-	
+	public const CTA_FIELD = 'featured_cta';
+
 	protected string $default_manual_card_label = 'Article';
-	
+
 	protected function get_locations(): array {
 		return [
 			[
@@ -38,8 +38,7 @@ class Featured_News_Block extends Query_Loop implements CTA_Field {
 	protected function get_fields(): array {
 		return [
 			$this->get_query_loop_group( self::NAME ),
-            $this->get_cta_field( self::NAME, 'All News Link', self::CTA_FIELD ),
+			$this->get_cta_field( self::NAME, 'All News Link', self::CTA_FIELD ),
 		];
 	}
-	
 }

--- a/src/Blocks/Magazine_Block.php
+++ b/src/Blocks/Magazine_Block.php
@@ -5,11 +5,11 @@ namespace UCSC\Blocks\Blocks;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
 class Magazine_Block extends ACF_Group {
-	
+
 	use With_CTA_Field;
 
 	public const NAME = 'ucsc_magazine_block';
-	
+
 	public const TITLE_LINE_1 = 'title_1';
 	public const TITLE_LINE_2 = 'title_2';
 	public const SUBTITLE     = 'subtitle';
@@ -94,7 +94,7 @@ class Magazine_Block extends ACF_Group {
 			'layout'       => 'block',
 		];
 	}
-	
+
 	protected function get_item_title(): array {
 		return [
 			'type'  => 'text',
@@ -131,5 +131,4 @@ class Magazine_Block extends ACF_Group {
 			'label' => esc_html__( 'Description', 'ucsc' ),
 		];
 	}
-
 }

--- a/src/Blocks/Media_Coverage_Block.php
+++ b/src/Blocks/Media_Coverage_Block.php
@@ -6,18 +6,18 @@ use UCSC\Blocks\Blocks\Contracts\CTA_Field;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
 class Media_Coverage_Block extends Query_Loop implements CTA_Field {
-	
+
 	use With_CTA_Field;
 
 	public const NAME = 'ucsc_media_coverage_block';
 
 	public const CTA_FIELD   = 'media_coverage_cta';
 	public const TITLE_FIELD = 'media_coverage_title';
-	
+
 	protected string $default_manual_card_label = 'Media Coverage';
-	protected array $allowed_post_types         = [ 'media_coverage', ];
+	protected array $allowed_post_types         = [ 'media_coverage' ];
 	protected int $max_manual_cards             = 6;
-	
+
 	protected function get_locations(): array {
 		return [
 			[
@@ -45,7 +45,7 @@ class Media_Coverage_Block extends Query_Loop implements CTA_Field {
 			$this->get_cta_field( self::NAME, 'All Coverage Link', self::CTA_FIELD ),
 		];
 	}
-	
+
 	protected function get_block_title_field(): array {
 		return [
 			'type'  => 'text',
@@ -54,5 +54,4 @@ class Media_Coverage_Block extends Query_Loop implements CTA_Field {
 			'label' => esc_html__( 'Title', 'ucsc' ),
 		];
 	}
-	
 }

--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -6,12 +6,12 @@ class News_Block extends ACF_Group {
 
 	public const NAME = 'news_query_block';
 
-	public const TITLE        = 'news_title';
+	public const TITLE         = 'news_title';
 	public const DESCRIPTION   = 'news_desc';
 	public const LAYOUT        = 'layout';
 	public const LAYOUT_LEFT   = 'layout_left';
 	public const LAYOUT_CENTRE = 'layout_centre';
-	
+
 	public const MORE_NEWS_LINK = 'more_news_link';
 
 	public const TAXONOMIES = 'taxonomies';
@@ -55,12 +55,12 @@ class News_Block extends ACF_Group {
 
 	protected function get_fields(): array {
 		$toggle_fields = [
-			self::HIDE_IMAGE 	=> esc_html__( 'Hide Featured Image', 'ucsc' ),
+			self::HIDE_IMAGE    => esc_html__( 'Hide Featured Image', 'ucsc' ),
 			self::HIDE_CATEGORY => esc_html__( 'Hide Category', 'ucsc' ),
 			self::HIDE_EXCERPT  => esc_html__( 'Hide Excerpt', 'ucsc' ),
-			self::HIDE_DATE 	=> esc_html__( 'Hide Published Date', 'ucsc' ),
-			self::HIDE_AUTHOR 	=> esc_html__( 'Hide Author', 'ucsc' ),
-			self::HIDE_TAGS 	=> esc_html__( 'Hide Tags', 'ucsc' ),
+			self::HIDE_DATE     => esc_html__( 'Hide Published Date', 'ucsc' ),
+			self::HIDE_AUTHOR   => esc_html__( 'Hide Author', 'ucsc' ),
+			self::HIDE_TAGS     => esc_html__( 'Hide Tags', 'ucsc' ),
 		];
 
 		$fields = [];
@@ -68,15 +68,18 @@ class News_Block extends ACF_Group {
 			$fields[] = $this->get_toggle_field( $name, $label );
 		}
 
-		return array_merge( [
-			$this->get_title_field(),
-			$this->get_desc_field(),
-			$this->get_layout_field(),
-			$this->get_more_news_link_field(),
-			$this->get_taxonomies_list(),
-			$this->get_taxonomies_items(),
-			$this->get_posts_per_page_field(), // Add the dropdown field here
-		], $fields );
+		return array_merge(
+			[
+				$this->get_title_field(),
+				$this->get_desc_field(),
+				$this->get_layout_field(),
+				$this->get_more_news_link_field(),
+				$this->get_taxonomies_list(),
+				$this->get_taxonomies_items(),
+				$this->get_posts_per_page_field(), // Add the dropdown field here
+			],
+			$fields
+		);
 	}
 
 	private function get_taxonomies_list(): array {
@@ -86,7 +89,7 @@ class News_Block extends ACF_Group {
 			'name'          => self::TAXONOMIES,
 			'type'          => 'select',
 			'choices'       => [],
-			'ui'       		=> 1,
+			'ui'            => 1,
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select a taxonomy to query.', 'ucsc' ),
 		];
@@ -99,8 +102,8 @@ class News_Block extends ACF_Group {
 			'name'          => self::TAX_ITEMS,
 			'type'          => 'select',
 			'multiple'      => 1,
-			'ui'      		=> 1,
-			'ajax'			=> 1,
+			'ui'            => 1,
+			'ajax'          => 1,
 			'choices'       => [],
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select the taxonomy term(s) to query.', 'ucsc' ),
@@ -150,7 +153,7 @@ class News_Block extends ACF_Group {
 			'type'  => 'textarea',
 		];
 	}
-	
+
 	private function get_more_news_link_field(): array {
 		return [
 			'key'   => $this->get_field_key( self::MORE_NEWS_LINK, self::NAME ),
@@ -167,9 +170,9 @@ class News_Block extends ACF_Group {
 			'name'          => 'posts_per_page',
 			'type'          => 'select',
 			'choices'       => [
-				3  => '3 Posts',
-				6  => '6 Posts',
-				9  => '9 Posts'
+				3 => '3 Posts',
+				6 => '6 Posts',
+				9 => '9 Posts',
 			],
 			'default_value' => 3, // Default to 3 posts
 			'ui'            => 1,
@@ -177,5 +180,4 @@ class News_Block extends ACF_Group {
 			'instructions'  => esc_html__( 'Select the number of posts to display in the block.', 'ucsc' ),
 		];
 	}
-
 }

--- a/src/Blocks/Photo_Of_The_Week_Block.php
+++ b/src/Blocks/Photo_Of_The_Week_Block.php
@@ -7,11 +7,11 @@ use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
 class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
-	
+
 	use With_CTA_Field;
 
 	public const NAME = 'ucsc_photo_of_the_week';
-	
+
 	public const TITLE = 'title';
 	public const PHOTO = 'ucsc_photo_single';
 
@@ -51,7 +51,7 @@ class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
 			'label' => esc_html__( 'Title', 'ucsc' ),
 		];
 	}
-	
+
 	protected function get_photo_field(): array {
 		return [
 			'type'          => 'post_object',
@@ -68,5 +68,4 @@ class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
 			],
 		];
 	}
-
 }

--- a/src/Blocks/Post_Header_Block.php
+++ b/src/Blocks/Post_Header_Block.php
@@ -5,15 +5,15 @@ namespace UCSC\Blocks\Blocks;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
 class Post_Header_Block extends ACF_Group {
-	
+
 	use With_CTA_Field;
 
 	public const NAME = 'ucsc_post_header_block';
-	
+
 	public const LAYOUT       = 'layout';
 	public const LAYOUT_SMALL = 'layout_small';
 	public const LAYOUT_BIG   = 'layout_big';
-	
+
 	protected function get_locations(): array {
 		return [
 			[
@@ -39,7 +39,7 @@ class Post_Header_Block extends ACF_Group {
 			$this->get_layout_field(),
 		];
 	}
-	
+
 	protected function get_layout_field(): array {
 		return [
 			'type'          => 'radio',
@@ -48,10 +48,9 @@ class Post_Header_Block extends ACF_Group {
 			'label'         => esc_html__( 'Layout', 'ucsc' ),
 			'choices'       => [
 				self::LAYOUT_SMALL => esc_html__( 'Small image', 'ucsc' ),
-				self::LAYOUT_BIG   => esc_html__( 'Big image', 'ucsc' )
+				self::LAYOUT_BIG   => esc_html__( 'Big image', 'ucsc' ),
 			],
 			'default_value' => self::LAYOUT_SMALL,
 		];
 	}
-
 }

--- a/src/Blocks/Press_Inquiries_Block.php
+++ b/src/Blocks/Press_Inquiries_Block.php
@@ -124,5 +124,4 @@ class Press_Inquiries_Block extends ACF_Group {
 			'toolbar'      => ACF_Toolbars::SIMPLE,
 		];
 	}
-
 }

--- a/src/Blocks/Query_Loop.php
+++ b/src/Blocks/Query_Loop.php
@@ -6,18 +6,18 @@ use UCSC\Blocks\Blocks\Contracts\Taxonomies;
 use UCSC\Blocks\Blocks\Traits\With_Taxonomies;
 
 abstract class Query_Loop extends ACF_Group implements Taxonomies {
-	
+
 	use With_Taxonomies;
-	
+
 	public const QUERY_LOOP = 'query_loop';
 	public const QUERY_TYPE = 'query_type';
 	public const LATEST     = 'latest';
 	public const AUTOMATIC  = 'automatic';
 	public const MANUAL     = 'manual';
-	
+
 	public const AUTOMATIC_GROUP = 'automatic_group';
 	public const CATEGORIES      = 'categories';
-	
+
 	public const MANUAL_CARDS = 'manual_cards';
 	public const MANUAL_CARD  = 'manual_card';
 
@@ -50,18 +50,18 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 	 * Add/Change in Block class in order to override
 	 */
 	protected string $block_name = '';
-	
+
 	protected array $allowed_post_types = [
 		'post',
 	];
-	
+
 	public function get_query_loop_group( string $name, array $allowed_post_types = [] ): array {
 		$this->block_name = $name;
-		
+
 		if ( ! empty( $allowed_post_types ) ) {
 			$this->allowed_post_types = $allowed_post_types;
 		}
-		
+
 		return [
 			'key'        => $this->get_field_key( self::QUERY_LOOP, $name ),
 			'type'       => 'group',
@@ -70,7 +70,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			'sub_fields' => $this->get_sub_fields(),
 		];
 	}
-	
+
 	protected function get_sub_fields(): array {
 		return [
 			$this->get_query_type_filed(),
@@ -78,7 +78,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			$this->get_manual_query(),
 		];
 	}
-	
+
 	protected function get_query_type_filed(): array {
 		return [
 			'key'           => $this->get_field_key( self::QUERY_TYPE, $this->block_name ),
@@ -94,7 +94,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			'default_value' => self::LATEST,
 		];
 	}
-	
+
 	protected function get_automatic_query(): array {
 		return [
 			'key'               => $this->get_field_key( self::AUTOMATIC_GROUP, $this->block_name ),
@@ -119,7 +119,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			],
 		];
 	}
-	
+
 	protected function get_categories_field(): array {
 		return [
 			'key'           => $this->get_field_key( self::CATEGORIES, self::AUTOMATIC_GROUP ),
@@ -133,7 +133,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			'instructions'  => esc_html__( 'Select the category to query.', 'ucsc' ),
 		];
 	}
-	
+
 	protected function get_manual_query(): array {
 		return [
 			'key'               => $this->get_field_key( self::MANUAL_CARDS, $this->block_name ),
@@ -158,7 +158,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			],
 		];
 	}
-	
+
 	protected function get_manual_card(): array {
 		return [
 			'key'           => $this->get_field_key( self::MANUAL_CARD, $this->block_name ),
@@ -171,5 +171,4 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 			'required'      => 0,
 		];
 	}
-
 }

--- a/src/Blocks/Related_Stories_Block.php
+++ b/src/Blocks/Related_Stories_Block.php
@@ -5,11 +5,11 @@ namespace UCSC\Blocks\Blocks;
 class Related_Stories_Block extends Query_Loop {
 
 	public const NAME = 'ucsc_related_stories_block';
-    
-    protected int $max_manual_cards = 3;
-	
+
+	protected int $max_manual_cards = 3;
+
 	protected string $default_manual_card_label = 'Story';
-	
+
 	protected function get_locations(): array {
 		return [
 			[
@@ -35,5 +35,4 @@ class Related_Stories_Block extends Query_Loop {
 			$this->get_query_loop_group( self::NAME ),
 		];
 	}
-	
 }

--- a/src/Blocks/Traits/With_CTA_Field.php
+++ b/src/Blocks/Traits/With_CTA_Field.php
@@ -3,7 +3,7 @@
 namespace UCSC\Blocks\Blocks\Traits;
 
 trait With_CTA_Field {
-	
+
 	public function get_cta_field( string $group_name, string $label, string $name = '' ): array {
 		return [
 			'label' => $label,
@@ -12,5 +12,4 @@ trait With_CTA_Field {
 			'key'   => $this->get_field_key( $name, $group_name ),
 		];
 	}
-
 }

--- a/src/Blocks/Traits/With_Taxonomies.php
+++ b/src/Blocks/Traits/With_Taxonomies.php
@@ -11,7 +11,7 @@ trait With_Taxonomies {
 			'name'          => self::TAXONOMIES,
 			'type'          => 'select',
 			'choices'       => [],
-			'ui'       		=> 1,
+			'ui'            => 1,
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select a taxonomy to query.', 'ucsc' ),
 		];
@@ -24,12 +24,11 @@ trait With_Taxonomies {
 			'name'          => self::TAX_ITEMS,
 			'type'          => 'select',
 			'multiple'      => 0,
-			'ui'      		=> 1,
-			'ajax'			=> 1,
+			'ui'            => 1,
+			'ajax'          => 1,
 			'choices'       => [],
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select the taxonomy term(s) to query.', 'ucsc' ),
 		];
 	}
-
 }

--- a/src/Components/Abstract_Controller.php
+++ b/src/Components/Abstract_Controller.php
@@ -4,11 +4,14 @@ namespace UCSC\Blocks\Components;
 
 class Abstract_Controller {
 
-    public function get_attributes( $classes = [] ): string {
-        
-        return wp_kses_data( get_block_wrapper_attributes( [
-            'class' => implode(' ',  $classes ),
-        ] ) );
-    }
-    
+	public function get_attributes( $classes = [] ): string {
+
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode( ' ', $classes ),
+				]
+			)
+		);
+	}
 }

--- a/src/Components/Featured_News_Block_Controller.php
+++ b/src/Components/Featured_News_Block_Controller.php
@@ -9,18 +9,18 @@ use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
 class Featured_News_Block_Controller extends Query_Loop_Controller {
-	
+
 	use With_Image_Size;
 	use With_Primary_Term;
 
 	protected int $number_of_posts_display = 4;
 
-	public function __construct($block) {
+	public function __construct( $block ) {
 		parent::__construct( $block );
 
 		$this->cta = (array) get_field( Featured_News_Block::CTA_FIELD ) ?: [];
 	}
-	
+
 	protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array {
 		$items = [];
 
@@ -32,12 +32,18 @@ class Featured_News_Block_Controller extends Query_Loop_Controller {
 			$image_meta = $image_id > 0 ? wp_get_attachment_metadata( $image_id ) : [];
 			$image_meta = is_array( $image_meta ) ? $image_meta : [];
 			$image_url  = wp_get_attachment_url( $image_id );
-			$taxonomy   =  $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ] ?: 'category';
-            $category   = $this->get_primary_term( $post_id, $taxonomy );
+			$taxonomy   = $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ] ?: 'category';
+			$category   = $this->get_primary_term( $post_id, $taxonomy );
 			$args       = [
 				'id'       => $post_id,
 				'title'    => get_the_title( $post_id ),
-				'image'    => array_merge( [ 'id' => $image_id, 'url' => $image_url ], $image_meta ),
+				'image'    => array_merge(
+					[
+						'id'  => $image_id,
+						'url' => $image_url,
+					],
+					$image_meta
+				),
 				'category' => $category,
 			];
 
@@ -51,5 +57,4 @@ class Featured_News_Block_Controller extends Query_Loop_Controller {
 
 		return $items;
 	}
-	
 }

--- a/src/Components/Magazine_Block_Controller.php
+++ b/src/Components/Magazine_Block_Controller.php
@@ -16,15 +16,22 @@ class Magazine_Block_Controller {
 	}
 
 	public function get_attributes(): string {
-		return wp_kses_data( get_block_wrapper_attributes([
-			'class' => implode(' ', [
-				'ucsc-magazine-block',
-				'alignfull',
-				'has-lightest-gray-background-color',
-				'has-global-padding',
-				'is-layout-constrained',
-			]),
-		]) );
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode(
+						' ',
+						[
+							'ucsc-magazine-block',
+							'alignfull',
+							'has-lightest-gray-background-color',
+							'has-global-padding',
+							'is-layout-constrained',
+						]
+					),
+				]
+			)
+		);
 	}
 
 	public function get_title_line_1(): string {
@@ -32,40 +39,43 @@ class Magazine_Block_Controller {
 
 		return strlen( $overline ) < 1 ? '' : $overline;
 	}
-	
+
 	public function get_title_line_2(): string {
 		$title = (string) get_field( Magazine_Block::TITLE_LINE_2 );
-		
+
 		return strlen( $title ) < 1 ? '' : $title;
 	}
-	
+
 	public function get_subtitle(): string {
 		$subtitle = (string) get_field( Magazine_Block::SUBTITLE );
-		
+
 		return strlen( $subtitle ) < 1 ? '' : $subtitle;
 	}
 
 	public function get_magazines(): array {
 		$magazines = (array) get_field( Magazine_Block::ITEMS );
-		
+
 		if ( empty( $magazines ) ) {
 			return [];
 		}
-		
-		return array_filter($magazines, static function ($magazine) {
-			return is_array( $magazine ) && ! empty( $magazine );
-		});
+
+		return array_filter(
+			$magazines,
+			static function ( $magazine ) {
+				return is_array( $magazine ) && ! empty( $magazine );
+			}
+		);
 	}
-	
+
 	public function make_tab_key( array $magazine, int $index, string $element = '' ): string {
-		return sprintf( 
+		return sprintf(
 			'%s-%s%s',
 			sanitize_title( $magazine[ Magazine_Block::ITEM_TITLE ] ),
 			$index + 1,
 			$element ? '__' . esc_html( $element ) : ''
 		);
 	}
-	
+
 	public function get_cta( array $magazine ): array {
 		if ( empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ] ) || empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['title'] ) || empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['url'] ) ) {
 			return [];
@@ -77,7 +87,7 @@ class Magazine_Block_Controller {
 			'target' => esc_attr( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['target'] ?: '_self' ),
 		];
 	}
-	
+
 	public function get_image( array $magazine ): string {
 		if ( empty( $magazine[ Magazine_Block::ITEM_IMAGE ] ) ) {
 			return '';
@@ -86,7 +96,7 @@ class Magazine_Block_Controller {
 		$image_id   = $magazine[ Magazine_Block::ITEM_IMAGE ];
 		$image_meta = $image_id > 0 ? wp_get_attachment_metadata( $image_id ) : [];
 		$image_url  = wp_get_attachment_url( $image_id );
-		
+
 		return sprintf(
 			'<img 
 				src="%s" 
@@ -94,14 +104,21 @@ class Magazine_Block_Controller {
 				class="" 
 			/>',
 			$image_url,
-			$this->build_srcset( array_merge( [ 'id' => $image_id, 'url' => $image_url ], $image_meta ) )
+			$this->build_srcset(
+				array_merge(
+					[
+						'id'  => $image_id,
+						'url' => $image_url,
+					],
+					$image_meta
+				)
+			)
 		);
 	}
-	
+
 	public function get_description( array $magazine ): string {
 		$description = (string) $magazine[ Magazine_Block::ITEM_DESC ];
 
 		return strlen( $description ) < 1 ? '' : $description;
 	}
-	
 }

--- a/src/Components/Media_Coverage_Controller.php
+++ b/src/Components/Media_Coverage_Controller.php
@@ -10,37 +10,44 @@ class Media_Coverage_Controller extends Query_Loop_Controller {
 
 	use With_Image_Size;
 	use With_Primary_Term;
-	
+
 	protected int $number_of_posts_display = 6;
-	protected array $post_types            = [ 'media_coverage', ];
-	
-	public function __construct($block) {
+	protected array $post_types            = [ 'media_coverage' ];
+
+	public function __construct( $block ) {
 		parent::__construct( $block );
 
 		$this->cta = (array) get_field( Media_Coverage_Block::CTA_FIELD ) ?: [];
 	}
 
 	public function get_attributes(): string {
-		return wp_kses_data( get_block_wrapper_attributes([
-			'class' => implode(' ', [
-				'ucsc-media-coverage-block',
-				'alignfull',
-				'has-lightest-gray-background-color',
-				'has-global-padding',
-				'is-layout-constrained',
-			]),
-		]) );
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode(
+						' ',
+						[
+							'ucsc-media-coverage-block',
+							'alignfull',
+							'has-lightest-gray-background-color',
+							'has-global-padding',
+							'is-layout-constrained',
+						]
+					),
+				]
+			)
+		);
 	}
 
 	public function get_title(): string {
 		$title = (string) get_field( Media_Coverage_Block::TITLE_FIELD );
-		
+
 		return strlen( $title ) < 1 ? '' : $title;
 	}
-	
+
 	public function is_internal_url( string $url ): bool {
 		$current_site = get_bloginfo( 'url' );
-		
+
 		return stripos( $url, $current_site ) !== false;
 	}
 
@@ -57,10 +64,13 @@ class Media_Coverage_Controller extends Query_Loop_Controller {
 			$args       = [
 				'id'           => $post_id,
 				'title'        => get_the_title( $post_id ),
-				'image'        => array_merge( [ 
-					'id'  => $image_id,
-					'url' => $image_url, 
-				], $image_meta ),
+				'image'        => array_merge(
+					[
+						'id'  => $image_id,
+						'url' => $image_url,
+					],
+					$image_meta
+				),
 				'source_title' => get_field( 'article_source', $post_id ),
 				'source_url'   => get_field( 'article_url', $post_id ),
 			];
@@ -68,7 +78,6 @@ class Media_Coverage_Controller extends Query_Loop_Controller {
 			$items[] = $args;
 		}
 
-		return $items;    
+		return $items;
 	}
-	
 }

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -7,10 +7,10 @@ use UCSC\Blocks\Request\News_Request;
 
 class News_Block_Controller {
 
-	public const POSTS    = 'news_posts';
-	public const PER_PAGE = 9;
-	private const CACHE_EXPIRY       = MINUTE_IN_SECONDS * 20;
-	private const DEFAULT_AUTHOR_ID  = 11;
+	public const POSTS              = 'news_posts';
+	public const PER_PAGE           = 9;
+	private const CACHE_EXPIRY      = MINUTE_IN_SECONDS * 20;
+	private const DEFAULT_AUTHOR_ID = 11;
 
 	protected array $block;
 	private string $taxonomy;
@@ -27,7 +27,7 @@ class News_Block_Controller {
 	private array|string $more_news_link;
 	private int $posts_per_page;
 
-	public function __construct($block) {
+	public function __construct( $block ) {
 		$this->block          = (array) $block;
 		$this->title          = get_field( News_Block::TITLE ) ?? '';
 		$this->description    = get_field( News_Block::DESCRIPTION ) ?? '';
@@ -51,7 +51,7 @@ class News_Block_Controller {
 	public function get_description(): string {
 		return $this->description;
 	}
-	
+
 	public function get_alignment(): string {
 		return $this->layout !== News_Block::LAYOUT_CENTRE ? ' align-header-left' : '';
 	}
@@ -68,7 +68,7 @@ class News_Block_Controller {
 		return $link;
 	}
 
-	public function build_srcset(array $sizes = []): string {
+	public function build_srcset( array $sizes = [] ): string {
 		if ( empty( $sizes ) ) {
 			return '';
 		}
@@ -82,46 +82,49 @@ class News_Block_Controller {
 	}
 
 	public function get_items(): array {
-		if (empty($this->taxonomy_ids) || empty($this->taxonomy)) {
+		if ( empty( $this->taxonomy_ids ) || empty( $this->taxonomy ) ) {
 			return [];
 		}
 
-		$response = get_transient($this->get_cache_key());
+		$response = get_transient( $this->get_cache_key() );
 
-		if (empty($response)) {
+		if ( empty( $response ) ) {
 			// Fetch data using the constant PER_PAGE for the API request
-			$response = (new News_Request())->request(News_Request::POSTS_ENDPOINT, [
-				'per_page'      => self::PER_PAGE, // Use the constant here
-				$this->taxonomy => implode(',', $this->taxonomy_ids),
-			]);
+			$response = ( new News_Request() )->request(
+				News_Request::POSTS_ENDPOINT,
+				[
+					'per_page'      => self::PER_PAGE, // Use the constant here
+					$this->taxonomy => implode( ',', $this->taxonomy_ids ),
+				]
+			);
 		}
 
-		if (empty($response)) {
+		if ( empty( $response ) ) {
 			return [];
 		}
 
 		$items = [];
 
-		foreach ($response as $item) {
+		foreach ( $response as $item ) {
 			$items[] = [
 				'title'        => $item['title']['rendered'] ?? '',
-				'excerpt'      => !$this->hide_excerpt ? $item['excerpt']['rendered'] ?? '' : '',
+				'excerpt'      => ! $this->hide_excerpt ? $item['excerpt']['rendered'] ?? '' : '',
 				'permalink'    => $item['link'] ?? '',
-				'image'        => !$this->hide_image ? $this->get_item_attachment($item) : [],
-				'raw_date'     => !$this->hide_date ? $item['date'] : '',
-				'publish_date' => !$this->hide_date ? wp_date(get_option('date_format', 'F j, Y'), strtotime($item['date'])) : '',
-				'authors'      => !$this->hide_author ? $this->get_authors($item) : '',
-				'tags'         => !$this->hide_tags ? $this->get_taxonomies($item, true) : [],
-				'categories'   => !$this->hide_category ? $this->get_taxonomies($item) : [],
+				'image'        => ! $this->hide_image ? $this->get_item_attachment( $item ) : [],
+				'raw_date'     => ! $this->hide_date ? $item['date'] : '',
+				'publish_date' => ! $this->hide_date ? wp_date( get_option( 'date_format', 'F j, Y' ), strtotime( $item['date'] ) ) : '',
+				'authors'      => ! $this->hide_author ? $this->get_authors( $item ) : '',
+				'tags'         => ! $this->hide_tags ? $this->get_taxonomies( $item, true ) : [],
+				'categories'   => ! $this->hide_category ? $this->get_taxonomies( $item ) : [],
 			];
 		}
 
-		set_transient($this->get_cache_key(), $response, self::CACHE_EXPIRY);
+		set_transient( $this->get_cache_key(), $response, self::CACHE_EXPIRY );
 
-		return array_slice($items, 0, $this->posts_per_page);
+		return array_slice( $items, 0, $this->posts_per_page );
 	}
 
-	protected function get_cache_key(string $prefix = ''): string {
+	protected function get_cache_key( string $prefix = '' ): string {
 		if ( ! empty( $prefix ) ) {
 			return sprintf( '%s_%s_%s', $prefix, self::POSTS, implode( '_', $this->taxonomy_ids ) );
 		}
@@ -129,7 +132,7 @@ class News_Block_Controller {
 		return sprintf( '%s_%s', self::POSTS, implode( '_', $this->taxonomy_ids ) );
 	}
 
-	protected function get_item_attachment(array $item): array {
+	protected function get_item_attachment( array $item ): array {
 		if ( ! isset( $item['featured_media'] ) || $item['featured_media'] <= 0 ) {
 			return [];
 		}
@@ -137,7 +140,7 @@ class News_Block_Controller {
 		$media = get_transient( $this->get_cache_key( 'attachment_' . $item['id'] ) );
 
 		if ( empty( $media ) ) {
-			$media = (new News_Request())->request( News_Request::ENDPOINT_BASE . 'media/' . $item['featured_media'] );
+			$media = ( new News_Request() )->request( News_Request::ENDPOINT_BASE . 'media/' . $item['featured_media'] );
 		}
 
 		if ( empty( $media ) ) {
@@ -156,14 +159,14 @@ class News_Block_Controller {
 		];
 	}
 
-	protected function get_authors(array $item): array {
+	protected function get_authors( array $item ): array {
 		if ( ! empty( $item['coauthors'] ) ) {
 			$authors = [];
 
 			foreach ( $item['coauthors'] as $author ) {
 				$user = get_transient( $this->get_cache_key( 'coauthor_' . $author ) );
 				if ( empty( $user ) ) {
-					$user = (new News_Request())->request( News_Request::ENDPOINT_BASE . 'coauthors/' . $author );
+					$user = ( new News_Request() )->request( News_Request::ENDPOINT_BASE . 'coauthors/' . $author );
 				}
 
 				if ( empty( $user ) ) {
@@ -179,7 +182,7 @@ class News_Block_Controller {
 
 		$user = get_transient( $this->get_cache_key( 'coauthor_' . self::DEFAULT_AUTHOR_ID ) );
 		if ( empty( $user ) ) {
-			$user = (new News_Request())->request( News_Request::ENDPOINT_BASE . 'coauthors/' . self::DEFAULT_AUTHOR_ID );
+			$user = ( new News_Request() )->request( News_Request::ENDPOINT_BASE . 'coauthors/' . self::DEFAULT_AUTHOR_ID );
 		}
 
 		if ( empty( $user ) ) {
@@ -191,23 +194,26 @@ class News_Block_Controller {
 		return [ $user['title']['rendered'] ?? $user['name'] ];
 	}
 
-	protected function get_taxonomies(array $item, bool $is_tag = false) {
+	protected function get_taxonomies( array $item, bool $is_tag = false ) {
 		$categories = [];
 
 		if ( empty( $item[ $this->taxonomy ] ) ) {
 			return [];
 		}
-		
+
 		$taxonomy = $is_tag ? 'tags' : $this->taxonomy;
 
 		$endpoint = News_Request::ENDPOINT_BASE . $taxonomy;
 
 		$items = get_transient( $this->get_cache_key( $taxonomy . '_' . $item['id'] ) );
 		if ( empty( $items ) ) {
-			$items = ( new News_Request() )->request($endpoint, [
-				'post'     => $item['id'],
-				'per_page' => 3,
-			] );
+			$items = ( new News_Request() )->request(
+				$endpoint,
+				[
+					'post'     => $item['id'],
+					'per_page' => 3,
+				]
+			);
 		}
 
 		if ( empty( $items ) ) {
@@ -222,5 +228,4 @@ class News_Block_Controller {
 
 		return $categories;
 	}
-
 }

--- a/src/Components/Photo_Of_The_Week_Archive_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Archive_Controller.php
@@ -11,23 +11,25 @@ class Photo_Of_The_Week_Archive_Controller {
 	use With_Image_Size;
 
 	public function get_query( $paged ): \WP_Query {
-		return new \WP_Query([
-			'post_type'      => Photo_Of_The_Week::NAME,
-			'post_status'    => 'publish',
-			'posts_per_page' => get_option( 'posts_per_page' ),
-			'orderby'        => 'date',
-			'order'          => 'DESC',
-			'paged'          => $paged,
-		]);
+		return new \WP_Query(
+			[
+				'post_type'      => Photo_Of_The_Week::NAME,
+				'post_status'    => 'publish',
+				'posts_per_page' => get_option( 'posts_per_page' ),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'paged'          => $paged,
+			]
+		);
 	}
-	
+
 	public function get_image(): array {
 		$image = get_field( Photo_Of_The_Week_Meta::IMAGE, get_the_ID() );
 
 		if ( empty( $image ) || $image['ID'] < 1 ) {
 			return [];
 		}
-		
+
 		return $image;
 	}
 
@@ -40,10 +42,13 @@ class Photo_Of_The_Week_Archive_Controller {
 
 		$image_meta = wp_get_attachment_metadata( $image['ID'] );
 
-		$image_data = array_merge( [ 
-			'id'  => $image['ID'], 
-			'url' => $image['url'],
-		], $image_meta );
+		$image_data = array_merge(
+			[
+				'id'  => $image['ID'],
+				'url' => $image['url'],
+			],
+			$image_meta
+		);
 
 		return sprintf(
 			'<img src="%s" srcset="%s" alt="%s" class="photo-of-the-week__image" />',
@@ -54,14 +59,15 @@ class Photo_Of_The_Week_Archive_Controller {
 	}
 
 	public function get_pagination( \WP_Query $query, int $paged ) {
-		return paginate_links([
-			'total'     => $query->max_num_pages,
-			'current'   => $paged,
-			'format'    => 'page/%#%',
-			'base'      => get_pagenum_link( 1 ) . '%_%',
-			'prev_text' => __( 'Previous', 'ucsc' ),
-			'next_text' => __( 'Next', 'ucsc' ),
-		]);
+		return paginate_links(
+			[
+				'total'     => $query->max_num_pages,
+				'current'   => $paged,
+				'format'    => 'page/%#%',
+				'base'      => get_pagenum_link( 1 ) . '%_%',
+				'prev_text' => __( 'Previous', 'ucsc' ),
+				'next_text' => __( 'Next', 'ucsc' ),
+			]
+		);
 	}
-
 }

--- a/src/Components/Photo_Of_The_Week_Block_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Block_Controller.php
@@ -21,33 +21,40 @@ class Photo_Of_The_Week_Block_Controller {
 	}
 
 	public function get_attributes(): string {
-		return wp_kses_data( get_block_wrapper_attributes([
-			'class' => implode(' ', [
-				'ucsc-photo-of-the-week-block',
-				'alignfull',
-				'has-black-background-color',
-				'has-white-color',
-				'has-global-padding',
-				'is-layout-constrained',
-			]),
-		]) );
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode(
+						' ',
+						[
+							'ucsc-photo-of-the-week-block',
+							'alignfull',
+							'has-black-background-color',
+							'has-white-color',
+							'has-global-padding',
+							'is-layout-constrained',
+						]
+					),
+				]
+			)
+		);
 	}
-	
+
 	public function get_title(): string {
 		$title = (string) get_field( Photo_Of_The_Week_Block::TITLE );
-		
+
 		return strlen( $title ) > 0 ? $title : '';
 	}
-	
+
 	public function get_photo(): ?array {
 		$photo = (string) get_field( Photo_Of_The_Week_Block::PHOTO );
-		
+
 		if ( empty( $photo ) ) {
 			return null;
 		}
-		
+
 		$image_data = $this->get_photo_image( $photo );
-		
+
 		if ( ! empty( $image_data ) ) {
 			$image = sprintf(
 				'<img src="%s" srcset="%s" alt="%s" class="photo-of-the-week__image" />',
@@ -56,7 +63,7 @@ class Photo_Of_The_Week_Block_Controller {
 				get_the_title( get_the_ID() )
 			);
 		}
-		
+
 		return [
 			'id'       => $photo,
 			'image'    => $image ?: '',
@@ -65,11 +72,11 @@ class Photo_Of_The_Week_Block_Controller {
 			'author'   => $this->get_photo_author( $photo ),
 		];
 	}
-	
+
 	public function get_photo_author( $photo_id ): string {
 		return (string) get_field( Photo_Of_The_Week_Meta::PHOTOGRAPHER, $photo_id );
 	}
-	
+
 	public function get_photo_image( $photo_id ): array {
 		$image = get_field( Photo_Of_The_Week_Meta::IMAGE, $photo_id );
 
@@ -79,10 +86,12 @@ class Photo_Of_The_Week_Block_Controller {
 
 		$image_meta = wp_get_attachment_metadata( $image['ID'] );
 
-		return array_merge( [
-			'id'  => $image['ID'],
-			'url' => $image['url'],
-		], $image_meta );
+		return array_merge(
+			[
+				'id'  => $image['ID'],
+				'url' => $image['url'],
+			],
+			$image_meta
+		);
 	}
-
 }

--- a/src/Components/Post_Header_Block_Controller.php
+++ b/src/Components/Post_Header_Block_Controller.php
@@ -6,9 +6,9 @@ use UCSC\Blocks\Blocks\Post_Header_Block;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
 class Post_Header_Block_Controller {
-	
+
 	use With_Primary_Term;
-	
+
 	protected array $block;
 
 	public function __construct( $block ) {
@@ -25,22 +25,26 @@ class Post_Header_Block_Controller {
 			$classes[] = 'ucsc-post-header-block--horizontal';
 		}
 
-		return wp_kses_data( get_block_wrapper_attributes([
-			'class' => implode( ' ', $classes ),
-		]) );
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode( ' ', $classes ),
+				]
+			)
+		);
 	}
 
 	public function is_horizontal_layout(): bool {
 		return $this->get_layout() === Post_Header_Block::LAYOUT_SMALL;
 	}
-	
+
 	public function get_primary_category(): ?string {
 		$category = $this->get_primary_term( get_the_ID() );
-		
+
 		if ( empty( $category ) ) {
 			return null;
 		}
-		
+
 		return (string) $category->name;
 	}
 
@@ -58,9 +62,8 @@ class Post_Header_Block_Controller {
 			'attribution' => $thumbnail->post_content,
 		];
 	}
-	
+
 	protected function get_layout() {
 		return get_field( Post_Header_Block::LAYOUT ) ?? Post_Header_Block::LAYOUT_SMALL;
 	}
-	
 }

--- a/src/Components/Press_Inquiries_Controller.php
+++ b/src/Components/Press_Inquiries_Controller.php
@@ -13,30 +13,37 @@ class Press_Inquiries_Controller {
 	}
 
 	public function get_attributes(): string {
-		return wp_kses_data( get_block_wrapper_attributes([
-			'class' => implode( ' ', [
-				'ucsc-press-inquiries-block',
-				'alignfull',
-				'is-layout-constrained',
-				'has-global-padding',
-			] ),
-		]) );
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode(
+						' ',
+						[
+							'ucsc-press-inquiries-block',
+							'alignfull',
+							'is-layout-constrained',
+							'has-global-padding',
+						]
+					),
+				]
+			)
+		);
 	}
-	
+
 	public function get_press_contacts(): array {
 		$contacts = get_field( Press_Inquiries_Block::PRESS_INQUIRIES );
-		
+
 		if ( empty( $contacts ) ) {
 			return [];
 		}
-		
+
 		return $contacts;
 	}
 
 	public function get_panel_id(): string {
 		return esc_attr( 'press-inquiries-block-' . $this->block['id'] );
 	}
-	
+
 	public function get_media_text(): string {
 		return (string) get_field( Press_Inquiries_Block::MEDIA_TEXT );
 	}
@@ -48,5 +55,4 @@ class Press_Inquiries_Controller {
 	public function get_media_image(): string {
 		return (string) get_field( Press_Inquiries_Block::MEDIA_IMAGE );
 	}
-	
 }

--- a/src/Components/Query_Loop_Controller.php
+++ b/src/Components/Query_Loop_Controller.php
@@ -6,7 +6,7 @@ use UCSC\Blocks\Blocks\Query_Loop;
 use UCSC\Blocks\Components\Traits\With_CTA;
 
 abstract class Query_Loop_Controller {
-	
+
 	use With_CTA;
 
 	protected array $block;
@@ -15,7 +15,7 @@ abstract class Query_Loop_Controller {
 	protected bool $exclude_current_post_from_query = true;
 
 	protected int $number_of_posts_display = 4;
-	protected array $post_types = [ 'post', ];
+	protected array $post_types            = [ 'post' ];
 
 	abstract protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array;
 
@@ -31,14 +31,14 @@ abstract class Query_Loop_Controller {
 		if ( empty( $query_type ) || $query_type === Query_Loop::LATEST ) {
 			return $this->get_latest_query_items();
 		}
-		
+
 		if ( $query_type === Query_Loop::AUTOMATIC ) {
 			return $this->get_automatic_query_items();
 		}
 
 		return $this->get_manual_query_items();
 	}
-	
+
 	protected function get_latest_query_items(): array {
 		$args = [
 			'fields'      => 'ids',
@@ -68,7 +68,7 @@ abstract class Query_Loop_Controller {
 		if ( is_array( $category_id ) ) {
 			$category_id = reset( $category_id );
 		}
-		
+
 		$args = [
 			'fields'      => 'ids',
 			'post_type'   => $this->post_types,
@@ -83,9 +83,9 @@ abstract class Query_Loop_Controller {
 				],
 			],
 		];
-		
+
 		if ( $this->exclude_current_post_from_query ) {
-			$args['exclude'] = [ get_the_ID(), ];
+			$args['exclude'] = [ get_the_ID() ];
 		}
 
 		$posts = get_posts( $args );
@@ -96,7 +96,7 @@ abstract class Query_Loop_Controller {
 
 		return $this->prepare_posts_for_display( $posts );
 	}
-	
+
 	protected function get_manual_query_items(): array {
 		$posts = $this->query_loop[ Query_Loop::MANUAL_CARDS ];
 
@@ -108,5 +108,4 @@ abstract class Query_Loop_Controller {
 
 		return $this->prepare_posts_for_display( $posts );
 	}
-
 }

--- a/src/Components/Related_Stories_Block_Controller.php
+++ b/src/Components/Related_Stories_Block_Controller.php
@@ -8,7 +8,7 @@ use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
 class Related_Stories_Block_Controller extends Query_Loop_Controller {
-	
+
 	use With_Image_Size;
 	use With_Primary_Term;
 
@@ -22,34 +22,44 @@ class Related_Stories_Block_Controller extends Query_Loop_Controller {
 			'has-global-padding',
 		];
 
-		return wp_kses_data( get_block_wrapper_attributes([
-			'class' => implode( ' ', $classes ),
-		]) );
+		return wp_kses_data(
+			get_block_wrapper_attributes(
+				[
+					'class' => implode( ' ', $classes ),
+				]
+			)
+		);
 	}
-	
+
 	protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array {
-        
-        $items = [];
+
+		$items = [];
 
 		foreach ( $posts as $post_id ) {
 			if ( is_bool( $post_id ) || $post_id < 1 ) {
 				continue;
 			}
-			
-            $image_id   = get_post_thumbnail_id( $post_id );
+
+			$image_id   = get_post_thumbnail_id( $post_id );
 			$image_meta = $image_id > 0 ? wp_get_attachment_metadata( $image_id ) : [];
 			$image_url  = wp_get_attachment_url( $image_id );
 
-            $taxonomy = 'category'; // Default taxonomy
-            if (isset($this->query_loop[Query_Loop::QUERY_LOOP][Taxonomies::TAXONOMIES])) {
-                $taxonomy = $this->query_loop[Query_Loop::QUERY_LOOP][Taxonomies::TAXONOMIES];
-            }
+			$taxonomy = 'category'; // Default taxonomy
+			if ( isset( $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ] ) ) {
+				$taxonomy = $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ];
+			}
 
-			$category   = $this->get_primary_term( $post_id, $taxonomy );
-			$args       = [
+			$category = $this->get_primary_term( $post_id, $taxonomy );
+			$args     = [
 				'id'       => $post_id,
 				'title'    => get_the_title( $post_id ),
-				'image'    => array_merge( [ 'id' => $image_id, 'url' => $image_url ], $image_meta !== false ? $image_meta : [] ),
+				'image'    => array_merge(
+					[
+						'id'  => $image_id,
+						'url' => $image_url,
+					],
+					$image_meta !== false ? $image_meta : []
+				),
 				'category' => $category,
 			];
 
@@ -58,5 +68,4 @@ class Related_Stories_Block_Controller extends Query_Loop_Controller {
 
 		return $items;
 	}
-	
 }

--- a/src/Components/Traits/With_CTA.php
+++ b/src/Components/Traits/With_CTA.php
@@ -8,10 +8,9 @@ trait With_CTA {
 		if ( empty( $this->cta ) || empty( $this->cta['title'] ) || empty( $this->cta['url'] ) ) {
 			return '';
 		}
-		
+
 		$classes = ! empty( $classes ) ? sprintf( 'class="%s"', implode( ' ', $classes ) ) : '';
 
 		return sprintf( '<a href="%s"%s target="%s">%s</a>', $this->cta['url'], $classes, $this->cta['target'] ?: '_self', $this->cta['title'] );
 	}
-
 }

--- a/src/Components/Traits/With_Image_Size.php
+++ b/src/Components/Traits/With_Image_Size.php
@@ -11,16 +11,15 @@ trait With_Image_Size {
 
 		$urls  = [];
 		$sizes = $image['sizes'] ?? [];
-		
+
 		if ( empty( $sizes ) ) {
 			return '';
 		}
-		
+
 		foreach ( $sizes as $size ) {
 			$urls[] = $image['url'] . ' ' . $size['width'] . 'w ' . $size['height'] . 'h';
 		}
 
 		return implode( ', ', $urls );
 	}
-	
 }

--- a/src/Components/Traits/With_Primary_Term.php
+++ b/src/Components/Traits/With_Primary_Term.php
@@ -45,5 +45,4 @@ trait With_Primary_Term {
 	protected function has_yoast(): bool {
 		return function_exists( 'yoast_get_primary_term_id' );
 	}
-
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -22,7 +22,7 @@ use UCSC\Blocks\Template\Post_Single;
 use UCSC\Blocks\Template\Template_Subscriber;
 
 class Core {
-	
+
 	public const PHOTOS_LOOP = 'photos-week-loop';
 
 	public const BLOCKS_PUBLIC = [
@@ -49,7 +49,7 @@ class Core {
 
 		return self::$instance;
 	}
-	
+
 	public function init(): void {
 		$this->blocks();
 		$this->scripts();
@@ -58,7 +58,7 @@ class Core {
 		$this->subscribers();
 		$this->templates();
 	}
-	
+
 	/**
 	 * @param array          $block      The block attributes.
 	 * @param string         $content    The block content.
@@ -81,19 +81,24 @@ class Core {
 		if ( ! $this->is_news_site() ) {
 			return;
 		}
-		
+
 		$templates = [
 			Photo_Of_The_Week_Archive::class,
 			Post_Single::class,
 		];
-		
-		add_action( 'after_setup_theme', static function () use ( $templates ): void {
-			foreach ( $templates as $template ) {
-				( new $template )->init();
-			}
-		}, 10, 0 );
+
+		add_action(
+			'after_setup_theme',
+			static function () use ( $templates ): void {
+				foreach ( $templates as $template ) {
+					( new $template() )->init();
+				}
+			},
+			10,
+			0
+		);
 	}
-	
+
 	protected function subscribers(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
@@ -102,7 +107,7 @@ class Core {
 		( new Integrations_Subscriber() )->init();
 		( new Template_Subscriber() )->init();
 	}
-	
+
 	protected function object_meta(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
@@ -110,67 +115,82 @@ class Core {
 
 		( new Object_Meta_Definer() )->register();
 	}
-	
+
 	protected function post_types(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
 		}
 
-		add_action( 'init', static function (): void {
-			( new Photo_Of_The_Week() )->register();
-		}, 10, 0 );
+		add_action(
+			'init',
+			static function (): void {
+				( new Photo_Of_The_Week() )->register();
+			},
+			10,
+			0
+		);
 	}
-	
+
 	protected function blocks(): void {
-		add_action( 'init', function (): void {
-			$this->init_blocks();
-			( new News_Blocks_Hooks() )->hooks();
-			( new Assets_Subscriber() )->register();
+		add_action(
+			'init',
+			function (): void {
+				$this->init_blocks();
+				( new News_Blocks_Hooks() )->hooks();
+				( new Assets_Subscriber() )->register();
 
-			if ( ! $this->is_news_site() ) {
-				return;
-			}
+				if ( ! $this->is_news_site() ) {
+					return;
+				}
 
-			( new Taxonomies_Hooks() )->hooks();
-		}, 10, 0 );
+				( new Taxonomies_Hooks() )->hooks();
+			},
+			10,
+			0
+		);
 	}
-	
+
 	protected function scripts(): void {
-		add_action( 'admin_enqueue_scripts', function (): void {
-			wp_register_script(
-				'ucsc-news-block-scripts',
-				UCSC_PLUGIN_URL . '/assets/js/news-block.js',
-				[],
-				false,
-				true
-			);
-			wp_enqueue_script( 'ucsc-news-block-scripts' );
+		add_action(
+			'admin_enqueue_scripts',
+			function (): void {
+				wp_register_script(
+					'ucsc-news-block-scripts',
+					UCSC_PLUGIN_URL . '/assets/js/news-block.js',
+					[],
+					false,
+					true
+				);
+				wp_enqueue_script( 'ucsc-news-block-scripts' );
 
-			if ( ! $this->is_news_site() ) {
-				return;
-			}
+				if ( ! $this->is_news_site() ) {
+					return;
+				}
 
-			wp_register_script(
-				'ucsc-custom-block-scripts',
-				UCSC_PLUGIN_URL . '/assets/js/custom-blocks.js',
-				[],
-				false,
-				true
-			);
-			wp_enqueue_script( 'ucsc-custom-block-scripts' );
-		}, 10, 0 );
+				wp_register_script(
+					'ucsc-custom-block-scripts',
+					UCSC_PLUGIN_URL . '/assets/js/custom-blocks.js',
+					[],
+					false,
+					true
+				);
+				wp_enqueue_script( 'ucsc-custom-block-scripts' );
+			},
+			10,
+			0
+		);
 	}
-	
+
 	protected function init_blocks(): void {
 		$args = [
 			'render_callback' => [ $this, 'render_template' ],
 		];
-		
+
 		foreach ( self::BLOCKS_PUBLIC as $block_class => $block_path ) {
 			register_block_type_from_metadata( trailingslashit( UCSC_DIR . $block_path ) . '/block.json', $args );
-			( new $block_class )->init();
+			( new $block_class() )->init();
 		}
-		
+
 		if ( ! $this->is_news_site() ) {
 			return;
 		}
@@ -180,12 +200,11 @@ class Core {
 			if ( ! class_exists( $block_class ) ) {
 				continue;
 			}
-			( new $block_class )->init();
+			( new $block_class() )->init();
 		}
 	}
-	
+
 	private function is_news_site(): bool {
 		return defined( 'UCSC_NEWS_SITE' ) && UCSC_NEWS_SITE;
 	}
-
 }

--- a/src/Hooks/News_Blocks_Hooks.php
+++ b/src/Hooks/News_Blocks_Hooks.php
@@ -7,11 +7,11 @@ use UCSC\Blocks\Request\News_Request;
 use UCSC\Blocks\Traits\With_Get_Field_Key;
 
 class News_Blocks_Hooks {
-	
+
 	use With_Get_Field_Key;
-	
+
 	private News_Request $request;
-	
+
 	public function __construct() {
 		$this->request = new News_Request();
 	}
@@ -60,7 +60,7 @@ class News_Blocks_Hooks {
 			$selected_tax = 'categories';
 		}
 
-		$choices = get_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ). '_' . $selected_tax );
+		$choices = get_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ) . '_' . $selected_tax );
 
 		if ( ! empty( $choices ) ) {
 			$field['choices'] = $choices;
@@ -70,7 +70,7 @@ class News_Blocks_Hooks {
 
 		$field['choices'] = $this->get_taxonomies_item_by_type( $selected_tax );
 
-		set_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ). '_' . $selected_tax, $field['choices'], MINUTE_IN_SECONDS * 20 );
+		set_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ) . '_' . $selected_tax, $field['choices'], MINUTE_IN_SECONDS * 20 );
 
 		return $field;
 	}
@@ -86,7 +86,7 @@ class News_Blocks_Hooks {
 			return $shortcut;
 		}
 
-		$choices = get_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ). '_' . $selected_taxonomy . '_shortcat' );
+		$choices = get_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ) . '_' . $selected_taxonomy . '_shortcat' );
 
 		if ( ! empty( $choices ) ) {
 			$shortcut['results'] = $choices;
@@ -113,7 +113,7 @@ class News_Blocks_Hooks {
 			];
 		}
 
-		set_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ). '_' . $selected_taxonomy . '_shortcat', $shortcut['results'], MINUTE_IN_SECONDS * 20 );
+		set_transient( $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ) . '_' . $selected_taxonomy . '_shortcat', $shortcut['results'], MINUTE_IN_SECONDS * 20 );
 
 		return $shortcut;
 	}
@@ -137,5 +137,4 @@ class News_Blocks_Hooks {
 
 		return $choices;
 	}
-
 }

--- a/src/Hooks/Taxonomies_Hooks.php
+++ b/src/Hooks/Taxonomies_Hooks.php
@@ -7,36 +7,35 @@ use UCSC\Blocks\Blocks\Featured_News_Block;
 use UCSC\Blocks\Traits\With_Get_Field_Key;
 
 class Taxonomies_Hooks {
-	
+
 	use With_Get_Field_Key;
-    
-    public const RESTRICTED_TAXONOMIES = [
-        'nav_menu',
-        'link_category',
-        'post_format',
-        'wp_theme',
-        'wp_template_part_area',
-        'wp_pattern_category',
-        'author',
-    ];
 
-	public function hooks(): void
-    {
-        add_filter('acf/load_field/name=' . Taxonomies::TAXONOMIES, [$this, 'load_taxonomies']);
-        add_filter('acf/load_field/name=' . Taxonomies::TAX_ITEMS, [$this, 'load_tax_items']);
+	public const RESTRICTED_TAXONOMIES = [
+		'nav_menu',
+		'link_category',
+		'post_format',
+		'wp_theme',
+		'wp_template_part_area',
+		'wp_pattern_category',
+		'author',
+	];
 
-        $query_blocks_search_key = [
-            $this->get_field_key(Taxonomies::TAX_ITEMS, Featured_News_Block::NAME),
-        ];
+	public function hooks(): void {
+		add_filter( 'acf/load_field/name=' . Taxonomies::TAXONOMIES, [ $this, 'load_taxonomies' ] );
+		add_filter( 'acf/load_field/name=' . Taxonomies::TAX_ITEMS, [ $this, 'load_tax_items' ] );
 
-        foreach ($query_blocks_search_key as $key) {
-            add_filter('acf/fields/select/query/key=' . $key, [$this, 'load_search_tax_items']);
-        }
-    }
-	
+		$query_blocks_search_key = [
+			$this->get_field_key( Taxonomies::TAX_ITEMS, Featured_News_Block::NAME ),
+		];
+
+		foreach ( $query_blocks_search_key as $key ) {
+			add_filter( 'acf/fields/select/query/key=' . $key, [ $this, 'load_search_tax_items' ] );
+		}
+	}
+
 	public function load_taxonomies( array $field ): array {
 		$taxonomies = get_taxonomies( [], false );
-       
+
 		if ( empty( $taxonomies ) ) {
 			return $field;
 		}
@@ -45,28 +44,30 @@ class Taxonomies_Hooks {
 		 * @var \WP_Taxonomy[] $taxonomies
 		 */
 		foreach ( $taxonomies as $key => $taxonomy ) {
-            if ( in_array( $key, self::RESTRICTED_TAXONOMIES ) ) {
-                continue;
-            }
-            
+			if ( in_array( $key, self::RESTRICTED_TAXONOMIES ) ) {
+				continue;
+			}
+
 			$field['choices'][ $taxonomy->name ] = $taxonomy->label;
 		}
 
 		return $field;
 	}
-	
+
 	public function load_tax_items( array $field ): array {
 		$selected_tax = get_field( Taxonomies::TAXONOMIES );
 
 		if ( empty( $selected_tax ) ) {
 			$selected_tax = 'category';
 		}
-		
-		$terms = get_terms( [
-			'taxonomy'   => $selected_tax,
-			'hide_empty' => true,
-		] );
-      
+
+		$terms = get_terms(
+			[
+				'taxonomy'   => $selected_tax,
+				'hide_empty' => true,
+			]
+		);
+
 		if ( empty( $terms ) || is_wp_error( $terms ) ) {
 			return $field;
 		}
@@ -80,7 +81,7 @@ class Taxonomies_Hooks {
 
 		return $field;
 	}
-	
+
 	public function load_search_tax_items( $shortcut ) {
 		if ( ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			return $shortcut;
@@ -92,18 +93,20 @@ class Taxonomies_Hooks {
 			return $shortcut;
 		}
 
-		$terms = get_terms( [
-			'taxonomy'   => $selected_taxonomy,
-			'hide_empty' => false,
-            'search'     => isset( $_POST['s'] ) ? sanitize_title_for_query( $_POST['s'] ) : '',
-		] );
-        
+		$terms = get_terms(
+			[
+				'taxonomy'   => $selected_taxonomy,
+				'hide_empty' => false,
+				'search'     => isset( $_POST['s'] ) ? sanitize_title_for_query( $_POST['s'] ) : '',
+			]
+		);
+
 		if ( empty( $terms ) || is_wp_error( $terms ) ) {
-            $shortcut['results'] = [];
-            
+			$shortcut['results'] = [];
+
 			return $shortcut;
 		}
-        
+
 		/**
 		 * @var \WP_Term[] $terms
 		 */
@@ -113,8 +116,7 @@ class Taxonomies_Hooks {
 				'text' => $term->name,
 			];
 		}
-		
+
 		return $shortcut;
 	}
-
 }

--- a/src/Integrations/ACF_Toolbars.php
+++ b/src/Integrations/ACF_Toolbars.php
@@ -3,14 +3,13 @@
 namespace UCSC\Blocks\Integrations;
 
 class ACF_Toolbars {
-    
-    public const SIMPLE = 'ucsc_simple_toolbar';
-    
-    public function register_simple_toolbar( array $toolbars ): array {
-        $toolbars[ self::SIMPLE ] = [];
-        $toolbars[ self::SIMPLE ][1] = [ 'bold', 'italic', 'link' ];
-        
-        return  $toolbars;
-    }
 
+	public const SIMPLE = 'ucsc_simple_toolbar';
+
+	public function register_simple_toolbar( array $toolbars ): array {
+		$toolbars[ self::SIMPLE ]    = [];
+		$toolbars[ self::SIMPLE ][1] = [ 'bold', 'italic', 'link' ];
+
+		return $toolbars;
+	}
 }

--- a/src/Integrations/Integrations_Subscriber.php
+++ b/src/Integrations/Integrations_Subscriber.php
@@ -3,7 +3,7 @@
 namespace UCSC\Blocks\Integrations;
 
 class Integrations_Subscriber {
-	
+
 	public const PRIMARY_TAX_SUPPORT = [
 		'academics',
 		'administration',
@@ -13,21 +13,30 @@ class Integrations_Subscriber {
 	];
 
 	public function init(): void {
-		add_filter( 'wpseo_primary_term_taxonomies', static function ( $taxonomies, $post_type, $all_taxonomies ) {
-			foreach ( self::PRIMARY_TAX_SUPPORT as $tax ) {
-				if ( ! isset( $all_taxonomies['academics'] ) ) {
-					continue;
+		add_filter(
+			'wpseo_primary_term_taxonomies',
+			static function ( $taxonomies, $post_type, $all_taxonomies ) {
+				foreach ( self::PRIMARY_TAX_SUPPORT as $tax ) {
+					if ( ! isset( $all_taxonomies['academics'] ) ) {
+						continue;
+					}
+
+					$taxonomies['academics'] = $all_taxonomies['academics'];
 				}
 
-				$taxonomies['academics'] = $all_taxonomies['academics'];
-			}
+				return $taxonomies;
+			},
+			10,
+			3
+		);
 
-			return $taxonomies;
-		}, 10, 3 );
-
-		add_filter( 'acf/fields/wysiwyg/toolbars', static function ( $toolbars ) {
-			return ( new ACF_Toolbars() )->register_simple_toolbar( (array) $toolbars );
-		}, 10, 1 );
+		add_filter(
+			'acf/fields/wysiwyg/toolbars',
+			static function ( $toolbars ) {
+				return ( new ACF_Toolbars() )->register_simple_toolbar( (array) $toolbars );
+			},
+			10,
+			1
+		);
 	}
-	
 }

--- a/src/Object_Meta/Object_Meta_Definer.php
+++ b/src/Object_Meta/Object_Meta_Definer.php
@@ -3,11 +3,15 @@
 namespace UCSC\Blocks\Object_Meta;
 
 class Object_Meta_Definer {
-    
-    public function register(): void {
-        add_action( 'init', static function () {
-            ( new Photo_Of_The_Week_Meta() )->init();
-        }, 10, 0 );
-    }
 
+	public function register(): void {
+		add_action(
+			'init',
+			static function () {
+				( new Photo_Of_The_Week_Meta() )->init();
+			},
+			10,
+			0
+		);
+	}
 }

--- a/src/Object_Meta/Photo_Of_The_Week_Meta.php
+++ b/src/Object_Meta/Photo_Of_The_Week_Meta.php
@@ -6,9 +6,9 @@ use UCSC\Blocks\Blocks\ACF_Group;
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
 class Photo_Of_The_Week_Meta extends ACF_Group {
-	
+
 	public const NAME = 'photo_of_the_week_post';
-	
+
 	public const PHOTOGRAPHER = 'photographer';
 	public const IMAGE        = 'image';
 
@@ -38,7 +38,7 @@ class Photo_Of_The_Week_Meta extends ACF_Group {
 			$this->get_image(),
 		];
 	}
-	
+
 	protected function get_photographer(): array {
 		return [
 			'label' => esc_html__( 'Photographer', 'ucsc' ),
@@ -58,5 +58,4 @@ class Photo_Of_The_Week_Meta extends ACF_Group {
 			'return_format' => 'array',
 		];
 	}
-
 }

--- a/src/Post_Types/Photo_Of_The_Week/Photo_Of_The_Week.php
+++ b/src/Post_Types/Photo_Of_The_Week/Photo_Of_The_Week.php
@@ -40,5 +40,4 @@ class Photo_Of_The_Week extends Post_Types {
 			'search_items' => esc_html__( 'Search Photos Of The Week', 'ucsc' ),
 		];
 	}
-
 }

--- a/src/Post_Types/Post_Types.php
+++ b/src/Post_Types/Post_Types.php
@@ -3,13 +3,12 @@
 namespace UCSC\Blocks\Post_Types;
 
 abstract class Post_Types {
-	
+
 	public const NAME = '';
-	
+
 	abstract public function get_args(): array;
 
 	public function register(): void {
 		register_post_type( static::NAME, $this->get_args() );
 	}
-
 }

--- a/src/Query/Query_Subscriber.php
+++ b/src/Query/Query_Subscriber.php
@@ -5,16 +5,20 @@ namespace UCSC\Blocks\Query;
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
 class Query_Subscriber {
-	
+
 	public function init(): void {
-		add_action( 'template_redirect', static function (): void {
-			if ( ! is_singular( Photo_Of_The_Week::NAME ) ) {
-				return;
-			}
+		add_action(
+			'template_redirect',
+			static function (): void {
+				if ( ! is_singular( Photo_Of_The_Week::NAME ) ) {
+					return;
+				}
 
-			wp_safe_redirect( get_post_type_archive_link( Photo_Of_The_Week::NAME ) );
-			exit;
-		}, 10, 0 );
+				wp_safe_redirect( get_post_type_archive_link( Photo_Of_The_Week::NAME ) );
+				exit;
+			},
+			10,
+			0
+		);
 	}
-
 }

--- a/src/Request/News_Request.php
+++ b/src/Request/News_Request.php
@@ -13,12 +13,15 @@ class News_Request {
 
 	public function request( string $endpoint, array $args = [], bool $with_pagination = false ): array {
 		try {
-			$url 		   = add_query_arg( $args, $this->get_endpoint_url( $endpoint ) );
-			$response 	   = wp_remote_get( $url, [
-				'headers' => [
-					'Accept' => 'application/json',
-				],
-			] );
+			$url           = add_query_arg( $args, $this->get_endpoint_url( $endpoint ) );
+			$response      = wp_remote_get(
+				$url,
+				[
+					'headers' => [
+						'Accept' => 'application/json',
+					],
+				]
+			);
 			$response_code = wp_remote_retrieve_response_code( $response );
 			$total_pages   = (int) wp_remote_retrieve_header( $response, 'X-Wp-Totalpages' );
 			if ( empty( $response_code ) || ! ( $response_code >= 200 && $response_code < 300 ) ) {
@@ -31,11 +34,18 @@ class News_Request {
 				return $this->data;
 			}
 
-			$this->page++;
+			++$this->page;
 
-			return $this->request( $endpoint, array_merge( $args, [
-				'page' => $this->page,
-			] ), true );
+			return $this->request(
+				$endpoint,
+				array_merge(
+					$args,
+					[
+						'page' => $this->page,
+					]
+				),
+				true
+			);
 		} catch ( \Throwable $exception ) {
 			return [];
 		}
@@ -45,15 +55,15 @@ class News_Request {
 		$env = wp_get_environment_type();
 
 		switch ( $env ) {
-            case 'production':
-                $base_url = 'https://news.ucsc.edu/';
-                break;
+			case 'production':
+				$base_url = 'https://news.ucsc.edu/';
+				break;
 			case 'staging':
 				$base_url = 'https://test-news-ucsc.pantheonsite.io/';
 				break;
-            case 'development':
-                $base_url = 'https://dev-news-ucsc.pantheonsite.io/';
-                break;    
+			case 'development':
+				$base_url = 'https://dev-news-ucsc.pantheonsite.io/';
+				break;
 			default:
 				$base_url = 'https://news.ucsc.edu/';
 				break;
@@ -61,5 +71,4 @@ class News_Request {
 
 		return sprintf( '%s%s', $base_url, $endpoint );
 	}
-
 }

--- a/src/Template/Blocks_Render.php
+++ b/src/Template/Blocks_Render.php
@@ -15,7 +15,7 @@ class Blocks_Render {
 	}
 
 	public function adjust_author_block( $block_content = '', $block = [] ) {
-		if ( ! is_singular() || ! function_exists( 'coauthors_posts_links' ) || ! (  isset( $block['blockName'] ) && 'core/post-author-name' === $block['blockName'] ) ) {
+		if ( ! is_singular() || ! function_exists( 'coauthors_posts_links' ) || ! ( isset( $block['blockName'] ) && 'core/post-author-name' === $block['blockName'] ) ) {
 			return $block_content;
 		}
 
@@ -27,17 +27,17 @@ class Blocks_Render {
 			false
 		);
 	}
-	
+
 	public function adjust_featured_image_block( $block_content = '', $block = [] ) {
-		if ( ! is_singular() || ! (  isset( $block['blockName'] ) && 'core/post-featured-image' === $block['blockName'] ) ) {
+		if ( ! is_singular() || ! ( isset( $block['blockName'] ) && 'core/post-featured-image' === $block['blockName'] ) ) {
 			return $block_content;
 		}
-		
+
 		$caption = get_the_post_thumbnail_caption() ?? '';
 		if ( get_post_thumbnail_id() > 0 ) {
 			$description = get_post( get_post_thumbnail_id() )->post_content ?? '';
 		}
-		
+
 		if ( ! empty( $caption ) ) {
 			$block_content = sprintf( '%s<p>%s</p>', $block_content, $caption );
 		}
@@ -45,12 +45,12 @@ class Blocks_Render {
 		if ( ! empty( $description ) ) {
 			$block_content = sprintf( '%s<p>%s</p>', $block_content, $description );
 		}
-		
+
 		return $block_content;
 	}
-	
+
 	public function adjust_post_terms_block( $block_content = '', $block = [] ) {
-		if ( ! is_single() || ! (  isset( $block['blockName'] ) && 'core/post-terms' === $block['blockName'] ) ) {
+		if ( ! is_single() || ! ( isset( $block['blockName'] ) && 'core/post-terms' === $block['blockName'] ) ) {
 			return $block_content;
 		}
 
@@ -62,9 +62,9 @@ class Blocks_Render {
 
 		return $block_content;
 	}
-	
+
 	public function adjust_social_share_block( $block_content = '', $block = [] ) {
-		if ( ! is_singular() || ! (  isset( $block['blockName'] ) && 'outermost/social-sharing' === $block['blockName'] ) ) {
+		if ( ! is_singular() || ! ( isset( $block['blockName'] ) && 'outermost/social-sharing' === $block['blockName'] ) ) {
 			return $block_content;
 		}
 
@@ -76,5 +76,4 @@ class Blocks_Render {
 
 		return $block_content;
 	}
-
 }

--- a/src/Template/Patterns/Pattern.php
+++ b/src/Template/Patterns/Pattern.php
@@ -3,16 +3,15 @@
 namespace UCSC\Blocks\Template\Patterns;
 
 abstract class Pattern {
-	
+
 	public const SLUG      = '';
 	public const NAMESPACE = 'ucsc-custom-functionality';
-	
+
 	abstract public function get_args(): array;
 
 	abstract public function register(): void;
-	
+
 	protected function build_pattern_name(): string {
 		return sprintf( '%s/%s', self::NAMESPACE, static::SLUG );
 	}
-
 }

--- a/src/Template/Photo_Of_The_Week_Archive.php
+++ b/src/Template/Photo_Of_The_Week_Archive.php
@@ -44,5 +44,4 @@ class Photo_Of_The_Week_Archive extends Template {
 
 		return $this->hydrate_block_template_by_post( get_post( $id ) );
 	}
-
 }

--- a/src/Template/Post_Single.php
+++ b/src/Template/Post_Single.php
@@ -5,18 +5,18 @@ namespace UCSC\Blocks\Template;
 use WP_Block_Template;
 
 class Post_Single extends Template {
-	
+
 	public const NAME    = 'ucsc_post_single_template';
 	public const SLUG    = 'post-single';
 	public const VERSION = '1.0';
-	
+
 	public function register( $query_result, $query, $template_type ) {
 		$template = $this->register_template();
-		
-		if ( empty( $template ) || ! is_single() || in_array('embed-post', $query['slug__in']) ) {
+
+		if ( empty( $template ) || ! is_single() || in_array( 'embed-post', $query['slug__in'] ) ) {
 			return $query_result;
 		}
-		
+
 		return $template;
 	}
 
@@ -40,8 +40,7 @@ class Post_Single extends Template {
 		if ( ! $id ) {
 			return null;
 		}
-		
+
 		return $this->hydrate_block_template_by_post( get_post( $id ) );
 	}
-
 }

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -7,20 +7,25 @@ use WP_Post;
 use WP_Query;
 
 abstract class Template {
-	
+
 	public const NAME      = '';
 	public const SLUG      = '';
 	public const NAMESPACE = 'ucsc-2022';
-	
+
 	public const VERSION          = '';
 	public const TEMPLATE_VERSION = 'ucsc_template_version';
-	
+
 	abstract protected function create_wp_block_template(): ?WP_Block_Template;
-	
+
 	public function init(): void {
-		add_filter( 'get_block_templates', function ( $query_result, $query, $template_type ) {
-			return $this->register( $query_result, $query, $template_type );
-		}, 10, 3 );
+		add_filter(
+			'get_block_templates',
+			function ( $query_result, $query, $template_type ) {
+				return $this->register( $query_result, $query, $template_type );
+			},
+			10,
+			3
+		);
 	}
 
 	public function get_slug(): string {
@@ -30,8 +35,8 @@ abstract class Template {
 	public function get_namespace(): string {
 		return static::NAMESPACE;
 	}
-    
-    abstract public function register( $query_result, $query, $template_type );
+
+	abstract public function register( $query_result, $query, $template_type );
 
 	public function register_template() {
 		$wp_block_template = $this->find_block_template_by_post( $this->get_slug(), $this->get_namespace() );
@@ -106,5 +111,4 @@ abstract class Template {
 
 		return $this->hydrate_block_template_by_post( $post );
 	}
-	
 }

--- a/src/Template/Template_Subscriber.php
+++ b/src/Template/Template_Subscriber.php
@@ -1,80 +1,89 @@
 <?php declare(strict_types=1);
- 
+
 namespace UCSC\Blocks\Template;
 
 class Template_Subscriber {
 
 	public function init(): void {
 		$block_renderer = Blocks_Render::instance();
-		
-		add_filter( 'render_block', static function ( $block_content = '', $block = [] ) use ( $block_renderer ) {
-			$block_content = $block_renderer->adjust_author_block( $block_content, $block );
-			$block_content = $block_renderer->adjust_featured_image_block( $block_content, $block );
-			$block_content = $block_renderer->adjust_post_terms_block( $block_content, $block );
-			$block_content = $block_renderer->adjust_social_share_block( $block_content, $block );
-			
-			return $block_content;
-		}, 100, 2 );
-		
-		add_action( 'init', static function (): void {
-			$post_type_object           = get_post_type_object( 'post' );
-			$post_type_object->template = [
-				[
-					'ucsc-custom-functionality/post-header-block',
-					[],
-				],
-				[
-					'ucsc-custom-functionality/press-inquiries',
-					[],
-				],
-				[
-					'core/paragraph',
-					[
-						'content' => 'Replace this text with the content of your story. Be sure to fill out the "excerpt" in the Post area on the right.',
-					],
-				],
-				[
-					'core/post-terms',
-					[
-						'term' => 'category',
-					],
-				],
-				[
-					'outermost/social-sharing',
-					[],
-					[
-						[
-							'outermost/social-sharing-link',
-							[
-								'service' => 'facebook',
-							],
-						],
-						[
-							'outermost/social-sharing-link',
-							[
-								'service' => 'linkedin',
-							],
-						],
-						[
-							'outermost/social-sharing-link',
-							[
-								'service' => 'reddit',
-							],
-						],
-						[
-							'outermost/social-sharing-link',
-							[
-								'service' => 'print',
-							],
-						],
-					],
-				],
-				[
-					'ucsc-custom-functionality/related-stories-block',
-					[],
-				],
-			];
-		}, 10, 0 );
-	}
 
+		add_filter(
+			'render_block',
+			static function ( $block_content = '', $block = [] ) use ( $block_renderer ) {
+				$block_content = $block_renderer->adjust_author_block( $block_content, $block );
+				$block_content = $block_renderer->adjust_featured_image_block( $block_content, $block );
+				$block_content = $block_renderer->adjust_post_terms_block( $block_content, $block );
+				$block_content = $block_renderer->adjust_social_share_block( $block_content, $block );
+
+				return $block_content;
+			},
+			100,
+			2
+		);
+
+		add_action(
+			'init',
+			static function (): void {
+				$post_type_object           = get_post_type_object( 'post' );
+				$post_type_object->template = [
+					[
+						'ucsc-custom-functionality/post-header-block',
+						[],
+					],
+					[
+						'ucsc-custom-functionality/press-inquiries',
+						[],
+					],
+					[
+						'core/paragraph',
+						[
+							'content' => 'Replace this text with the content of your story. Be sure to fill out the "excerpt" in the Post area on the right.',
+						],
+					],
+					[
+						'core/post-terms',
+						[
+							'term' => 'category',
+						],
+					],
+					[
+						'outermost/social-sharing',
+						[],
+						[
+							[
+								'outermost/social-sharing-link',
+								[
+									'service' => 'facebook',
+								],
+							],
+							[
+								'outermost/social-sharing-link',
+								[
+									'service' => 'linkedin',
+								],
+							],
+							[
+								'outermost/social-sharing-link',
+								[
+									'service' => 'reddit',
+								],
+							],
+							[
+								'outermost/social-sharing-link',
+								[
+									'service' => 'print',
+								],
+							],
+						],
+					],
+					[
+						'ucsc-custom-functionality/related-stories-block',
+						[],
+					],
+				];
+			},
+			10,
+			0
+		);
+	}
 }

--- a/src/Traits/With_Get_Field_Key.php
+++ b/src/Traits/With_Get_Field_Key.php
@@ -3,9 +3,8 @@
 namespace UCSC\Blocks\Traits;
 
 trait With_Get_Field_Key {
-	
+
 	public function get_field_key( string $name, string $group_name ): string {
 		return sprintf( '%s_%s', $group_name, $name );
 	}
-
 }

--- a/src/views/featured-news-block/index.php
+++ b/src/views/featured-news-block/index.php
@@ -24,14 +24,14 @@ if ( empty( $items ) && is_admin() ) {
 ?>
 <section <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<div class="ucsc-featured-news-block__inner">
-		<?php foreach ( $items as $key => $item ) :  ?>
+		<?php foreach ( $items as $key => $item ) : ?>
 			<a href="<?php echo esc_url( get_the_permalink( $item['id'] ) ); ?>" class="ucsc-featured-news-block__card<?php echo $key === 0 ? esc_attr( ' ucsc-featured-news-block__card--sticky' ) : ''; ?>">
 				<?php if ( ! empty( $item['image'] ) && $item['image']['id'] > 0 ) : ?>
 					<div class="ucsc-featured-news-block__card-image">
 						<?php $image_alt = get_post_meta( $item['image']['id'], '_wp_attachment_image_alt', true ); ?>
 						<img 
-							src="<?php echo esc_url( $item['image']['url'] );?>" 
-							srcset="<?php echo $c->build_srcset( $item['image'] );?>" 
+							src="<?php echo esc_url( $item['image']['url'] ); ?>" 
+							srcset="<?php echo $c->build_srcset( $item['image'] ); ?>" 
 							class="ucsc-featured-news-block__featured-image"
 							alt="<?php echo ! empty( $image_alt ) ? esc_attr( get_post_meta( $item['image']['id'], '_wp_attachment_image_alt' )[0] ) : $item['title']; ?>"
 						/>
@@ -39,7 +39,7 @@ if ( empty( $items ) && is_admin() ) {
 				<?php endif; ?>
 				<?php if ( ! empty( $item['category'] ) ) : ?>
 					<span class="ucsc-featured-news-block__category">
-						<?php echo $item['category']->name ?>
+						<?php echo $item['category']->name; ?>
 					</span>
 				<?php endif; ?>
 	

--- a/src/views/magazine-block/index.php
+++ b/src/views/magazine-block/index.php
@@ -42,13 +42,13 @@ $magazines = $c->get_magazines();
 					type="button"
 					role="tab"
 					tabindex="-1"
-					data-key="<?php echo $c->make_tab_key( $magazine, $index )?>"
-					aria-labelledby="<?php echo $c->make_tab_key( $magazine, $index, 'label' )?>"
+					data-key="<?php echo $c->make_tab_key( $magazine, $index ); ?>"
+					aria-labelledby="<?php echo $c->make_tab_key( $magazine, $index, 'label' ); ?>"
 					aria-selected="false"
-					aria-controls="<?php echo $c->make_tab_key( $magazine, $index, 'panel' )?>"
+					aria-controls="<?php echo $c->make_tab_key( $magazine, $index, 'panel' ); ?>"
 				>
-					<span id="<?php echo $c->make_tab_key( $magazine, $index, 'label' )?>" class="ucsc-magazine-block__post-title">
-						<?php echo $magazine[ Magazine_Block::ITEM_TITLE ];?>
+					<span id="<?php echo $c->make_tab_key( $magazine, $index, 'label' ); ?>" class="ucsc-magazine-block__post-title">
+						<?php echo $magazine[ Magazine_Block::ITEM_TITLE ]; ?>
 					</span>
 					<?php if ( $magazine[ Magazine_Block::ITEM_BYLINE ] ) : ?>
 					<span class="ucsc-magazine-block__post-author has-base-font-size">
@@ -63,35 +63,35 @@ $magazines = $c->get_magazines();
 		<div class="ucsc-magazine-block__panels">
 			<?php foreach ( $magazines as $index => $magazine ) : ?>
 			<div
-				id="<?php echo $c->make_tab_key( $magazine, $index, 'panel' )?>"
+				id="<?php echo $c->make_tab_key( $magazine, $index, 'panel' ); ?>"
 				role="tabpanel"
-				aria-labelledby="<?php echo $c->make_tab_key( $magazine, $index, 'label' )?>"
+				aria-labelledby="<?php echo $c->make_tab_key( $magazine, $index, 'label' ); ?>"
 				aria-hidden="true"
 				inert
 				class="ucsc-magazine-block__panel"
 			>
 				<?php echo $c->get_image( $magazine ); ?>
 
-				<?php  $cta = $c->get_cta( $magazine ); ?>
-				<?php  $description = $c->get_description( $magazine ); ?>
+				<?php $cta = $c->get_cta( $magazine ); ?>
+				<?php $description = $c->get_description( $magazine ); ?>
 				<?php if ( $description || $cta ) : ?>
 				<div class="ucsc-magazine-block__post-excerpt">
 					<?php if ( $description ) : ?>
 					<p>
 						<?php echo $description; ?>
 					</p>
-					<?php endif;?>
+					<?php endif; ?>
 
 					<?php if ( $cta ) : ?>
 					<div class="ucsc-magazine-block__post-cta is-style-ucsc-blue">
-						<a href="<?php echo $cta['url'] ?>" target="<?php echo $cta['target'] ?>" class="wp-element-button">
-							<?php echo $cta['title'] ?>
+						<a href="<?php echo $cta['url']; ?>" target="<?php echo $cta['target']; ?>" class="wp-element-button">
+							<?php echo $cta['title']; ?>
 							<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none">
 								<path d="M0.767045 9.84203L0 9.08138L7.86222 1.21277H1.57244L1.58523 0.158081H9.67756V8.2632H8.61009L8.62287 1.97981L0.767045 9.84203Z" fill="currentColor"/>
 							</svg>
 						</a>
 					</div>
-					<?php endif;?>
+					<?php endif; ?>
 				</div>
 				<?php endif; ?>
 

--- a/src/views/media-coverage-block/index.php
+++ b/src/views/media-coverage-block/index.php
@@ -19,12 +19,12 @@ $title = $c->get_title();
 
 	<?php if ( ! empty( $items ) ) : ?>
 	<div class="ucsc-media-coverage-block__grid">
-		<?php foreach ( $items as $item ) :  ?>
-		<a class="ucsc-media-coverage-block__post" href="<?php echo $item['source_url'];?>"<?php echo ! $c->is_internal_url( $item['source_url'] ) ? ' target="_blank" rel="nofollow"' : '';?>>
+		<?php foreach ( $items as $item ) : ?>
+		<a class="ucsc-media-coverage-block__post" href="<?php echo $item['source_url']; ?>"<?php echo ! $c->is_internal_url( $item['source_url'] ) ? ' target="_blank" rel="nofollow"' : ''; ?>>
 			<?php if ( ! empty( $item['image'] ) && $item['image']['id'] > 0 ) : ?>
 			<img
-				src="<?php echo esc_url( $item['image']['url'] );?>"
-				srcset="<?php echo $c->build_srcset( $item['image'] );?>"
+				src="<?php echo esc_url( $item['image']['url'] ); ?>"
+				srcset="<?php echo $c->build_srcset( $item['image'] ); ?>"
 				class="ucsc-featured-block__card-image"
 			/>
 			<?php endif; ?>

--- a/src/views/news-block/index.php
+++ b/src/views/news-block/index.php
@@ -33,16 +33,16 @@ if ( empty( $items ) ) {
 		</div>
 	<?php endif; ?>
 
-	<?php if ( count($items) < 1 ) { ?>
+	<?php if ( count( $items ) < 1 ) { ?>
 		<p><?php echo _e( 'No articles found', 'ucsc' ); ?></p>
 	<?php } else { ?>
 		<div class="ucsc-news-block__cards-wrapper">
 		<?php foreach ( $items as $item ) : ?>
-			<a href="<?php echo esc_url( $item['permalink'] );?>" class="ucsc-news-block__card">
+			<a href="<?php echo esc_url( $item['permalink'] ); ?>" class="ucsc-news-block__card">
 				<?php if ( ! empty( $item['image'] ) ) : ?>
 					<img 
-	src="<?php echo esc_url( $item['image']['raw_url'] );?>" 
-	srcset="<?php echo esc_attr( $c->build_srcset( $item['image']['sizes']) );?>" 
+	src="<?php echo esc_url( $item['image']['raw_url'] ); ?>" 
+	srcset="<?php echo esc_attr( $c->build_srcset( $item['image']['sizes'] ) ); ?>" 
 	class="ucsc-news-block__card-image"
 	alt="<?php echo esc_attr( $item['image']['alt'] ?? '' ); ?>"
 />
@@ -56,7 +56,7 @@ if ( empty( $items ) ) {
 				
 				<h3 class="ucsc-news-block__card-title">
 					<span class="ucsc-news-block__card-title--inner">
-						<?php echo esc_html( $item['title'] );?>
+						<?php echo esc_html( $item['title'] ); ?>
 					</span>
 				</h3>
 	
@@ -69,7 +69,7 @@ if ( empty( $items ) ) {
 				<?php if ( ! empty( $item['publish_date'] ) || ! empty( $item['authors'] ) || ! empty( $item['tags'] ) ) : ?>
 					<div class="ucsc-news-block__card-meta">
 						<?php if ( ! empty( $item['publish_date'] ) ) : ?>
-							<time class="ucsc-news-block__card-date" datetime="<?php echo esc_attr( $item['raw_date']); ?>">
+							<time class="ucsc-news-block__card-date" datetime="<?php echo esc_attr( $item['raw_date'] ); ?>">
 								<?php echo esc_html( $item['publish_date'] ); ?>
 							</time>
 						<?php endif; ?>
@@ -86,7 +86,7 @@ if ( empty( $items ) ) {
 	
 						<?php if ( ! empty( $item['tags'] ) ) : ?>
 							<span class="ucsc-news-block__card-tags">
-							<?php foreach ($item['tags'] as $tag ) { ?>
+							<?php foreach ( $item['tags'] as $tag ) { ?>
 								<span class="ucsc-news-block__card-tag">
 									<?php echo esc_html( $tag ); ?>
 								</span>

--- a/src/views/post-header-block/index.php
+++ b/src/views/post-header-block/index.php
@@ -24,7 +24,8 @@ $image        = $c->get_image();
 		<?php
 		// The horizontal layout now opens a columns wrapper inside the container,
 		// while the vertical layout closes the container and continues on.
-		if ( $c->is_horizontal_layout() ) : ?>
+		if ( $c->is_horizontal_layout() ) :
+			?>
 		<div class="ucsc-post-header-block__columns">
 		<?php else : ?>
 		</div>
@@ -34,7 +35,7 @@ $image        = $c->get_image();
 			<hgroup>
 				<?php if ( ! empty( $primary_term ) ) : ?>
 					<p class="ucsc-post-header-block__eyebrow has-one-font-size has-ucsc-primary-yellow-color">
-						<?php echo $primary_term ?>
+						<?php echo $primary_term; ?>
 					</p>
 				<?php endif; ?>
 				<h1 class="ucsc-post-header-block__title has-seven-font-size">
@@ -92,7 +93,8 @@ $image        = $c->get_image();
 		<?php
 		// The horizontal layout needs to close both the columns wrapper and the
 		// container element.
-		if ( $c->is_horizontal_layout() ) : ?>
+		if ( $c->is_horizontal_layout() ) :
+			?>
 		</div>
 		</div>
 		<?php endif; ?>

--- a/src/views/press-inquiries/index.php
+++ b/src/views/press-inquiries/index.php
@@ -79,7 +79,7 @@ if ( $is_empty ) {
 								<path d="M9.5 0.5V5.5H14.5" />
 								<path d="M9.5 0.5H1.5V15.5H14.5V5.5L9.5 0.5Z" />
 							</svg>
-							<a href="<?php echo $media_file ?>" target="_blank">
+							<a href="<?php echo $media_file; ?>" target="_blank">
 								<?php echo esc_html__( 'Access Paper', 'ucsc' ); ?>
 							</a>
 						</p>
@@ -92,14 +92,14 @@ if ( $is_empty ) {
 									<path d="M14 15.5H2C1.60218 15.5 1.22064 15.342 0.93934 15.0607C0.658035 14.7794 0.5 14.3978 0.5 14V2C0.5 1.60218 0.658035 1.22064 0.93934 0.93934C1.22064 0.658035 1.60218 0.5 2 0.5H14C14.3978 0.5 14.7794 0.658035 15.0607 0.93934C15.342 1.22064 15.5 1.60218 15.5 2V14C15.5 14.3978 15.342 14.7794 15.0607 15.0607C14.7794 15.342 14.3978 15.5 14 15.5Z" />
 									<path d="M5 6.5C5.82843 6.5 6.5 5.82843 6.5 5C6.5 4.17157 5.82843 3.5 5 3.5C4.17157 3.5 3.5 4.17157 3.5 5C3.5 5.82843 4.17157 6.5 5 6.5Z" />
 								</svg>
-								<a href="<?php echo $media_image ?>" target="_blank">
+								<a href="<?php echo $media_image; ?>" target="_blank">
 									<?php echo esc_html__( 'Image Download', 'ucsc' ); ?>
 								</a>
 							</p>
 						<?php endif; ?>
 
 						<?php if ( ! empty( $media_text ) ) : ?>
-							<?php echo $media_text ?>
+							<?php echo $media_text; ?>
 						<?php endif; ?>
 					</div>
 					<?php endif; ?>

--- a/src/views/related-stories-block/index.php
+++ b/src/views/related-stories-block/index.php
@@ -31,15 +31,15 @@ if ( empty( $items ) ) {
 		<?php echo esc_html__( 'Related Stories', 'ucsc' ); ?>
 	</h2>
 	<div class="ucsc-related-stories-block__inner">
-		<?php foreach ( $items as $key => $item ) :  ?>
+		<?php foreach ( $items as $key => $item ) : ?>
 		<a href="<?php echo esc_url( get_the_permalink( $item['id'] ) ); ?>" class="ucsc-related-stories-block__card-link">
 			<article class="ucsc-related-stories-block__card">
 				<?php if ( ! empty( $item['image'] ) && $item['image']['id'] > 0 ) : ?>
 				<div class="ucsc-related-stories-block__card-image">
 					<?php $image_alt = get_post_meta( $item['image']['id'], '_wp_attachment_image_alt', true ); ?>
 					<img 
-						src="<?php echo esc_url( $item['image']['url'] );?>" 
-						srcset="<?php echo $c->build_srcset( $item['image'] );?>" 
+						src="<?php echo esc_url( $item['image']['url'] ); ?>" 
+						srcset="<?php echo $c->build_srcset( $item['image'] ); ?>" 
 						class="ucsc-related-stories-block__featured-image"
 						alt="<?php echo ! empty( $image_alt ) ? esc_attr( get_post_meta( $item['image']['id'], '_wp_attachment_image_alt' )[0] ) : $item['title']; ?>"
 					/>
@@ -49,7 +49,7 @@ if ( empty( $items ) ) {
 				<hgroup>
 					<?php if ( ! empty( $item['category'] ) ) : ?>
 					<p class="ucsc-related-stories-block__card-category">
-						<?php echo $item['category']->name ?>
+						<?php echo $item['category']->name; ?>
 					</p>
 					<?php endif; ?>
 


### PR DESCRIPTION
## What does this do/fix?

Step 1 of #116 — the mechanical PHP pass. Runs `composer lint-fix` across `plugin.php`, `lib/` and `src/`, clearing the auto-fixable portion of the backlog that became visible once #101 repaired the linters.

**phpcs: 1345 errors → 550.** 65 files touched.

Changes are whitespace, indentation, call-signature wrapping, brace placement, trailing commas, quote style, `dirname( __FILE__ )` → `__DIR__`, `new Foo` → `new Foo()`, one standalone `$x++` → `++$x`, and semicolons inserted before closing tags in view templates.

Landing this now because there are currently **zero other open PRs** — this touches 65 files and will conflict with anything in flight.

## ⚠️ phpcbf introduced a behaviour regression. It is fixed here.

The `WordPress.WP.CapitalPDangit` sniff "corrected" the spelling of WordPress inside a regex that matches a **hostname**, not the product name:

```diff
- preg_match( "/\.wordpress(\-dev)?|\.local/usmx", $site_url )
+ preg_match( '/\.WordPress(\-dev)?|\.local/usmx', $site_url )
```

The pattern has no `i` modifier and `parse_url( …, PHP_URL_HOST )` returns a lowercase host, so this silently stops matching:

| host | before | after |
|---|---|---|
| `site.wordpress.ucsc.edu` | 1 | **0** |
| `site.wordpress-dev.ucsc.edu` | 1 | **0** |
| `site.local` | 1 | 1 |
| `www.ucsc.edu` | 0 | 0 |

Every development and dev-tier site would have fallen through to production site search instead of searching `ucsc.edu` — silently, with no error.

Fixed by restoring the lowercase pattern and wrapping the block in a scoped `phpcs:disable WordPress.WP.CapitalPDangit` with the reason inline. Verified the annotation survives repeated `composer lint-fix` runs (it took two attempts — the directive has to precede the docblock, not sit inside it, or the comment gets rewritten too).

**This is the argument for reviewing formatter output rather than trusting it.** It was not visible in the diff at a glance; it surfaced only from a token-level comparison.

## How "behaviour-preserving" was verified

Not by reading 65 diffs. A script compared the **PHP token stream** of every changed file before and after, ignoring only what a formatter may legitimately touch (whitespace; whitespace within comments and inline HTML).

That first pass flagged 18 files. Each difference fell into one of six known-equivalent transformations, so a second pass normalised exactly those six and re-compared:

1. trailing comma before `]` or `)`
2. `dirname( __FILE__ )` → `__DIR__`
3. `"double"` vs `'single'` quotes, where the string has no escape or `$`
4. `new Foo` → `new Foo()`
5. `$x++` → `++$x` (operators dropped, but total count must match)
6. inserted `;` before a closing tag

After normalisation **one** file still differed — `lib/functions/shortcodes.php`, the regression above. With that fixed, its executable code compares byte-for-byte identical with comments stripped (162 tokens both sides).

## Tests

```bash
composer install
composer lint          # 550 errors, down from 1345
npm run build          # green
```

Verified locally:

- [x] All 65 changed files pass `php -l`
- [x] Token-stream equivalence across all 65 files, no unexplained differences
- [x] `npm run build` green
- [x] `CapitalPDangit` no longer reported, and the regex survives repeated `lint-fix` runs
- [x] Regression reproduced and confirmed fixed against four representative hostnames

Reviewer checks — the diff is large but uniform, so spot-checking is reasonable:

- [ ] `lib/functions/shortcodes.php` — read this one properly, it is the only non-mechanical change
- [ ] Site search on a `*.wordpress-dev.*` host still scopes to `ucsc.edu`
- [ ] View templates in `src/views/*/index.php` still render (semicolons were inserted before `?>`)
- [ ] `git diff -w` is empty apart from `shortcodes.php` and the structural rewraps

## Not included

Step 2 of #116 (eslint/prettier, ~135 errors) follows as a separate PR. Steps 3–5 — docblocks, `WordPress.Security.EscapeOutput`, and the long tail — remain open on #116; the 80 escaping findings are the ones with real security relevance and want a careful pass of their own.
