### PR TITLE
style: apply eslint --fix formatting to block scripts (135 -> 2 errors)

### DIFF
--- a/src/views/magazine-block/index.js
+++ b/src/views/magazine-block/index.js
@@ -6,154 +6,156 @@ import './editor.scss';
 
 const el = {
 	blocks: null,
-}
+};
 
 /**
  * Get a block's tab elements.
- * 
- * @param {HTMLElement} block 
+ *
+ * @param {HTMLElement} block
  */
-const getBlockTabs = (block) => {
-  return Array.from(block.querySelectorAll('[role="tab"]'))
-}
+const getBlockTabs = ( block ) => {
+	return Array.from( block.querySelectorAll( '[role="tab"]' ) );
+};
 
 /**
  * Get tab's panel element.
- * 
- * @param {HTMLButtonElement} tab 
- * @param {HTMLElement} block 
+ *
+ * @param {HTMLButtonElement} tab
+ * @param {HTMLElement}       block
  */
-const getTabPanel = (tab, block) => {
-  return document.getElementById(tab.getAttribute('aria-controls'))
-}
+const getTabPanel = ( tab, block ) => {
+	return document.getElementById( tab.getAttribute( 'aria-controls' ) );
+};
 
 /**
  * Get the tab that is offset from the given tab by the given amount.	Loop at
  * the beginning and end if necessary.
- * 
- * @param {HTMLButtonElement} fromTab
+ *
+ * @param {HTMLButtonElement}   fromTab
  * @param {HTMLButtonElement[]} tabs
- * @param {number} offset
+ * @param {number}              offset
  * @return {HTMLButtonElement}
  */
 const getRelativeTab = ( fromTab, tabs, offset ) => {
-	const currentIndex = tabs.indexOf( fromTab )
-	let newIndex = ( currentIndex + offset ) % tabs.length
+	const currentIndex = tabs.indexOf( fromTab );
+	let newIndex = ( currentIndex + offset ) % tabs.length;
 	if ( newIndex < 0 ) {
-		newIndex = tabs.length + newIndex
+		newIndex = tabs.length + newIndex;
 	}
-	return tabs[ newIndex ]
-}
+	return tabs[ newIndex ];
+};
 
 /**
  * Make the given tab the active one.
- * 
- * @param {HTMLButtonElement} tab 
- * @param {HTMLElement} block 
+ *
+ * @param {HTMLButtonElement} tab
+ * @param {HTMLElement}       block
  */
-const activateTab = (tab, block) => {
-  // Deactivate other tabs.
-  for (const otherTab of getBlockTabs(block)) {
-    if (otherTab === tab) {
-      continue
-    }
-    
-    otherTab.tabIndex = -1
-    otherTab.setAttribute('aria-selected', 'false')
-    const panel = getTabPanel(otherTab, block)
-    if (panel) {
-      panel.setAttribute('aria-hidden', 'true')
-      panel.setAttribute('inert', '')
-    }
-  }
+const activateTab = ( tab, block ) => {
+	// Deactivate other tabs.
+	for ( const otherTab of getBlockTabs( block ) ) {
+		if ( otherTab === tab ) {
+			continue;
+		}
 
-  // Activate this tab.
-  tab.tabIndex = 0
-  tab.setAttribute('aria-selected', 'true')
-  const panel = getTabPanel(tab, block)
-  if (panel) {
-    panel.setAttribute('aria-hidden', 'false')
-    panel.removeAttribute('inert')
-  }
+		otherTab.tabIndex = -1;
+		otherTab.setAttribute( 'aria-selected', 'false' );
+		const panel = getTabPanel( otherTab, block );
+		if ( panel ) {
+			panel.setAttribute( 'aria-hidden', 'true' );
+			panel.setAttribute( 'inert', '' );
+		}
+	}
 
-  // Scroll to the current tab (only affects mobile).
-  const tabList = tab.closest('[role="tablist"]')
-  if (tabList) {
-    tabList.scrollTo({
-      left: tab.offsetLeft,
-      behavior: 'smooth',
-    })
-  }
-}
+	// Activate this tab.
+	tab.tabIndex = 0;
+	tab.setAttribute( 'aria-selected', 'true' );
+	const panel = getTabPanel( tab, block );
+	if ( panel ) {
+		panel.setAttribute( 'aria-hidden', 'false' );
+		panel.removeAttribute( 'inert' );
+	}
+
+	// Scroll to the current tab (only affects mobile).
+	const tabList = tab.closest( '[role="tablist"]' );
+	if ( tabList ) {
+		tabList.scrollTo( {
+			left: tab.offsetLeft,
+			behavior: 'smooth',
+		} );
+	}
+};
 
 /**
  * Callback for when the keydown event on a tab toggle.
- * 
+ *
  * @param {HTMLButtonElement} tab
- * @param {HTMLElement} block
- * @param {KeyboardEvent} event
+ * @param {HTMLElement}       block
+ * @param {KeyboardEvent}     event
  */
 const onTabKeydown = ( tab, block, event ) => {
-  const allTabs = getBlockTabs(block)
-  if (!allTabs.length) {
-    return
-  }
+	const allTabs = getBlockTabs( block );
+	if ( ! allTabs.length ) {
+		return;
+	}
 
-	let newTab = null
+	let newTab = null;
 	switch ( event.key ) {
 		case 'ArrowUp':
-			newTab = getRelativeTab( tab, allTabs, -1 )
-			break
+			newTab = getRelativeTab( tab, allTabs, -1 );
+			break;
 		case 'ArrowDown':
-			newTab = getRelativeTab( tab, allTabs, 1 )
-			break
+			newTab = getRelativeTab( tab, allTabs, 1 );
+			break;
 		case 'Home':
-			newTab = allTabs[ 0 ]
-			break
+			newTab = allTabs[ 0 ];
+			break;
 		case 'End':
-			newTab = allTabs[ allTabs.length - 1 ]
-			break
+			newTab = allTabs[ allTabs.length - 1 ];
+			break;
 	}
 
 	if ( newTab ) {
-    activateTab(newTab, block)
-    newTab.focus()
-		event.stopPropagation()
-		event.preventDefault()
+		activateTab( newTab, block );
+		newTab.focus();
+		event.stopPropagation();
+		event.preventDefault();
 	}
-}
+};
 
 const bindEvents = () => {
-  for (const block of el.blocks) {
-    for (const tab of getBlockTabs(block)) {
-      // Toggle tabs on click.
-      tab.addEventListener('click', () => {
-        activateTab(tab, block)
-      })
+	for ( const block of el.blocks ) {
+		for ( const tab of getBlockTabs( block ) ) {
+			// Toggle tabs on click.
+			tab.addEventListener( 'click', () => {
+				activateTab( tab, block );
+			} );
 
-      // Provide keyboard support.
-      tab.addEventListener( 'keydown', event => {
-				onTabKeydown( tab, block, event )
-			} )
-    }
-  }
-}
+			// Provide keyboard support.
+			tab.addEventListener( 'keydown', ( event ) => {
+				onTabKeydown( tab, block, event );
+			} );
+		}
+	}
+};
 
 const cacheElements = () => {
-	el.blocks = Array.from(document.querySelectorAll( '.ucsc-magazine-block' ))
-}
+	el.blocks = Array.from(
+		document.querySelectorAll( '.ucsc-magazine-block' )
+	);
+};
 
 const init = () => {
-	cacheElements()
-	bindEvents()
+	cacheElements();
+	bindEvents();
 
-  // Activate the first tab in each block.
-  for (const block of el.blocks) {
-    const tabs = getBlockTabs(block)
-    if (tabs.length > 0) {
-      activateTab(tabs[0], block)
-    }
-  }
-}
+	// Activate the first tab in each block.
+	for ( const block of el.blocks ) {
+		const tabs = getBlockTabs( block );
+		if ( tabs.length > 0 ) {
+			activateTab( tabs[ 0 ], block );
+		}
+	}
+};
 
-document.addEventListener( 'DOMContentLoaded', init )
+document.addEventListener( 'DOMContentLoaded', init );

--- a/src/views/press-inquiries/index.js
+++ b/src/views/press-inquiries/index.js
@@ -7,48 +7,51 @@ import './editor.scss';
 
 const el = {
 	blocks: null,
-}
+};
 
 /**
  * Callback for when the toggle button is actioned.
- * 
+ *
  * @param {HTMLButtonElement} button
- * @param {HTMLElement} block
+ * @param {HTMLElement}       block
  */
 const onToggleClick = ( button, block ) => {
-  const content = block.querySelector( '.ucsc-press-inquiries-block__inner-wrapper' )
-  if (!content) {
-    return
-  }
+	const content = block.querySelector(
+		'.ucsc-press-inquiries-block__inner-wrapper'
+	);
+	if ( ! content ) {
+		return;
+	}
 
-  if (button.getAttribute('aria-expanded') === 'true') {
-    button.setAttribute('aria-expanded', 'false')
-    content.setAttribute('inert', '')
-  }
-  else {
-    button.setAttribute('aria-expanded', 'true')
-    content.removeAttribute('inert')
-  }
-}
+	if ( button.getAttribute( 'aria-expanded' ) === 'true' ) {
+		button.setAttribute( 'aria-expanded', 'false' );
+		content.setAttribute( 'inert', '' );
+	} else {
+		button.setAttribute( 'aria-expanded', 'true' );
+		content.removeAttribute( 'inert' );
+	}
+};
 
 const bindEvents = () => {
-  for (const block of el.blocks) {
-    const button = block.querySelector('button[aria-controls]')
-    if (button) {
-      button.addEventListener('click', () => {
-        onToggleClick(button, block)
-      })
-    }
-  }
-}
+	for ( const block of el.blocks ) {
+		const button = block.querySelector( 'button[aria-controls]' );
+		if ( button ) {
+			button.addEventListener( 'click', () => {
+				onToggleClick( button, block );
+			} );
+		}
+	}
+};
 
 const cacheElements = () => {
-	el.blocks = Array.from(document.querySelectorAll( '.ucsc-press-inquiries-block' ))
-}
+	el.blocks = Array.from(
+		document.querySelectorAll( '.ucsc-press-inquiries-block' )
+	);
+};
 
 const init = () => {
-	cacheElements()
-	bindEvents()
-}
+	cacheElements();
+	bindEvents();
+};
 
-document.addEventListener( 'DOMContentLoaded', init )
+document.addEventListener( 'DOMContentLoaded', init );


### PR DESCRIPTION
## What does this do/fix?

Step 2 of #116 — the mechanical JS pass. Runs `npm run lint:js:fix`, clearing the auto-fixable eslint backlog exposed once #101 made `npm run lint` actually invoke eslint.

**eslint: 135 errors → 2.** Two files touched, both block scripts.

Independent of #118 (the PHP pass) — different files, no overlap, either can merge first.

## Only cosmetic rules were applied

Counting rule IDs on `main` before the fix:

| count | rule | kind |
|---|---|---|
| 127 | `prettier/prettier` | formatting |
| 6 | `jsdoc/check-line-alignment` | comment alignment |
| 1 | `no-unused-vars` | not auto-fixable |
| 1 | `jsdoc/require-returns-description` | not auto-fixable |

The 133 fixed all came from the two formatting rules. **No logic-affecting rule was auto-applied** — which is the main thing worth checking when letting a tool rewrite source.

Verified rather than assumed: both versions of each changed file were parsed with espree and their ASTs compared with position data, ranges and comments stripped. Identical on both files.

(This check exists because the equivalent one on the PHP side found a real regression — see #118, where phpcbf silently broke hostname matching. Formatter output is worth verifying.)

## The 2 remaining errors

Left deliberately. Neither is auto-fixable and both want a human decision, not a formatter:

```
src/views/magazine-block/index.js:26:28  'block' is defined but never used     no-unused-vars
src/views/magazine-block/index.js:37:1   Missing JSDoc @return description     jsdoc/require-returns-description
```

The `no-unused-vars` one is worth a proper look — an unused parameter in a tab-handling function may indicate a bug rather than dead code. Tracked under the remaining #116 work rather than guessed at here.

## Tests

```bash
npm install
npm run lint:js     # 2 errors, down from 135
npm run lint:css    # clean
npm run build       # green
```

Verified locally:

- [x] AST equivalence on both changed files (espree, position/comment stripped)
- [x] `npm run build` green
- [x] `npm run lint:css` clean
- [x] eslint down to the 2 non-auto-fixable errors

Reviewer checks:

- [ ] Magazine block tab switching still works on the front end
- [ ] Press Inquiries block still renders and behaves

Both files are `viewScript`-style DOM code, so a browser check is the meaningful test — the AST comparison covers the rest.
