### PR TITLE
docs: add docblocks to bootstrap and infrastructure (slice 1/4)

### DIFF
--- a/lib/functions/admin-menus.php
+++ b/lib/functions/admin-menus.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'ucsc_custom_functionality_remove_from_admin_bar' ) ) {
 	/**
 	 * Remove items from Admin Bar
 	 *
-	 * @param mixed $wp_admin_bar
+	 * @param mixed $wp_admin_bar The WP_Admin_Bar instance being built.
 	 * @return void
 	 * Removes unwanted items from the WP Admin bar
 	 * @package

--- a/lib/functions/scripts/disable-xmlrpc.php
+++ b/lib/functions/scripts/disable-xmlrpc.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Disable XMLRPC
  *
@@ -8,6 +7,12 @@
  * see: https://pantheon.io/docs/wordpress-best-practices#avoid-xml-rpc-attacks
  *
  * XMLRPC is always disabled when this plugin is active.
+ *
+ * @package      ucsc
+ * @since        0.1.0
+ * @link         https://github.com/ucsc/ucsc-custom-functionality.git
+ * @author       UC Santa Cruz
+ * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
 add_filter(
@@ -19,5 +24,5 @@ add_filter(
 );
 
 // Removes the link from the <head>.
-// Avoids a11y issue with broken link
+// Avoids an accessibility issue with the broken link.
 remove_action( 'wp_head', 'rsd_link' );

--- a/lib/functions/scripts/ga.php
+++ b/lib/functions/scripts/ga.php
@@ -1,16 +1,31 @@
 <?php
-
 /**
  * Google Analytics and Tag Manager
-
- * This file contains the functions necessary to add the UC Santa Cruz Google Analytics and Tag Manager snippets to the site.
+ *
+ * This file contains the functions necessary to add the UC Santa Cruz Google
+ * Analytics and Tag Manager snippets to the site.
+ *
+ * The container ID is hardcoded, so every site sharing this plugin reports
+ * into the same container; making it configurable is tracked in #113.
+ *
+ * @package      ucsc
+ * @since        0.1.0
+ * @link         https://github.com/ucsc/ucsc-custom-functionality.git
+ * @author       UC Santa Cruz
+ * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
-
 
 add_action( 'wp_head', 'ucsc_google_tag_manager_head', 1 );
 
 add_action( 'wp_body_open', 'ucsc_google_tag_manager_body' );
 
+/**
+ * Print the Google Tag Manager snippet in the document head.
+ *
+ * Hooked early on wp_head so the container loads before other tracking.
+ *
+ * @return void
+ */
 function ucsc_google_tag_manager_head() {
 	?>
 <!-- Google Tag Manager -->
@@ -23,6 +38,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	<?php
 }
 
+/**
+ * Print the Google Tag Manager noscript fallback after the opening body tag.
+ *
+ * Requires theme support for wp_body_open.
+ *
+ * @return void
+ */
 function ucsc_google_tag_manager_body() {
 	?>
 	<!-- Google Tag Manager (noscript) -->

--- a/lib/functions/scripts/site-improve.php
+++ b/lib/functions/scripts/site-improve.php
@@ -1,12 +1,27 @@
 <?php
-
 /**
  * Site Improve script
- * This file contains the functions necessary to add the UC Santa Cruz Site Improve script to the site.
+ *
+ * This file contains the functions necessary to add the UC Santa Cruz Site
+ * Improve script to the site.
+ *
+ * The analytics ID is hardcoded, so every site sharing this plugin reports
+ * into the same account; making it configurable is tracked in #113.
+ *
+ * @package      ucsc
+ * @since        0.1.0
+ * @link         https://github.com/ucsc/ucsc-custom-functionality.git
+ * @author       UC Santa Cruz
+ * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
 add_action( 'wp_footer', 'ucsc_site_improve_analytics' );
 
+/**
+ * Print the Site Improve analytics snippet in the footer.
+ *
+ * @return void
+ */
 function ucsc_site_improve_analytics() {
 	?>
 <!-- Siteimprove -->

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Add Plugin settings and info page
  *
@@ -12,9 +11,12 @@
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
-/** Register new menu and page */
-
 if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
+	/**
+	 * Register the plugin's page under the Settings menu.
+	 *
+	 * @return void
+	 */
 	function ucsc_add_settings_page() {
 		add_options_page( 'UCSC Custom Functionality plugin page', 'UCSC Custom Functionality', 'manage_options', 'ucsc-custom-functionality-settings', 'ucsc_render_plugin_settings_page' );
 	}
@@ -22,15 +24,18 @@ if ( ! function_exists( 'ucsc_add_settings_page' ) ) {
 add_action( 'admin_menu', 'ucsc_add_settings_page' );
 
 
-/**
- * HTML output of Settings page
- *
- * note: This page typically displays a form for displaying any settings options.
- * It is not needed at this point.
- * https://developer.wordpress.org/plugins/settings/custom-settings-page/
- */
-
 if ( ! function_exists( 'ucsc_render_plugin_settings_page' ) ) {
+	/**
+	 * Render the settings page.
+	 *
+	 * Note: this page is informational. It lists what the plugin provides and
+	 * links to the release notes; it deliberately registers no settings, so
+	 * there is no form and no Settings API usage.
+	 *
+	 * @link https://developer.wordpress.org/plugins/settings/custom-settings-page/
+	 *
+	 * @return void
+	 */
 	function ucsc_render_plugin_settings_page() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;

--- a/lib/functions/shortcodes.php
+++ b/lib/functions/shortcodes.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'ucsc_custom_functionality_google_search' ) ) {
 	 */
 	function ucsc_custom_functionality_google_search() {
 
-		// Configuration params to be added to the output string
+		// Configuration params to be added to the output string.
 		$script_source = 'https://cse.google.com/cse.js?cx=012090462228956765947:d0ywvq7bxee';
 		$site_url      = parse_url( get_site_url(), PHP_URL_HOST );
 
@@ -36,7 +36,7 @@ if ( ! function_exists( 'ucsc_custom_functionality_google_search' ) ) {
 		}
 		// phpcs:enable WordPress.WP.CapitalPDangit
 
-		// Return the configured string for Google Search results to display on the page
+		// Return the configured string for Google Search results to display on the page.
 		return sprintf( '<script async src="%s"></script><div class="gcse-searchresults-only" data-queryParameterName="s" data-as_sitesearch="%s"></div>', $script_source, $search_url );
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Plugin Name: UCSC Custom Functionality
  * Plugin URI:  https://github.com/ucsc/ucsc-custom-functionality.git
@@ -8,8 +8,14 @@
  * Author URI:  https://github.com/ucsc
  * License:     GPL2
  *
- * @package ucsc-custom-functionality
+ * Entry point. Defines the plugin constants, includes the procedural
+ * lib/functions/ features, and boots the namespaced src/ layer through
+ * Core once ACF PRO is confirmed present.
+ *
+ * @package ucsc
  */
+
+declare(strict_types=1);
 
 // Set plugin directory.
 define( 'UCSC_DIR', __DIR__ );
@@ -53,6 +59,9 @@ if ( ! function_exists( 'ucsc_enqueue_admin_styles' ) ) {
 	 * @author UCSC
 	 *
 	 * @link https://developer.wordpress.org/reference/hooks/admin_enqueue_scripts/#Example:_Load_CSS_File_from_a_plugin_on_specific_Admin_Page
+	 *
+	 * @param string $hook The current admin page hook suffix. Unused; the screen
+	 *                     is resolved through get_current_screen() instead.
 	 */
 	function ucsc_enqueue_admin_styles( $hook ): void {
 		$settings_css   = plugin_dir_url( __FILE__ ) . 'lib/css/admin-settings.css';

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -1,9 +1,30 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Shared asset-manifest helper.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Assets;
 
+/**
+ * Reads the asset manifests webpack generates alongside each built entry.
+ */
 trait Assets {
 
+	/**
+	 * Read a generated asset manifest.
+	 *
+	 * These files return an array with 'dependencies' and 'version' keys.
+	 * A missing or malformed file yields an empty array rather than an error,
+	 * so a block with no built assets degrades quietly.
+	 *
+	 * @param string $file_path Absolute path to the generated *.asset.php file.
+	 *
+	 * @return array The manifest contents, or an empty array.
+	 */
 	public function get_asset_file_args( string $file_path ): array {
 		if ( ! file_exists( $file_path ) ) {
 			return [];

--- a/src/Assets/Assets_Enqueuer.php
+++ b/src/Assets/Assets_Enqueuer.php
@@ -1,19 +1,66 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Block asset enqueuing.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Assets;
 
+/**
+ * Enqueues the built CSS and JS for every registered UCSC block.
+ *
+ * Discovery is by registry scan rather than by iterating the registered
+ * classes: any block whose name contains "ucsc-custom-functionality/" is
+ * picked up. The last segment of that block name must therefore match the
+ * build directory name, or the asset lookup silently finds nothing.
+ */
 class Assets_Enqueuer {
 
 	use Assets;
 
+	/**
+	 * Absolute filesystem path to the built assets directory.
+	 *
+	 * @var string
+	 */
 	protected string $assets_path;
+
+	/**
+	 * Public URL of the built assets directory.
+	 *
+	 * @var string
+	 */
 	protected string $assets_path_uri;
 
+	/**
+	 * Resolve the built-assets directory as both a path and a URL.
+	 *
+	 * @param string $assets_folder Path to the built assets, relative to the plugin root.
+	 */
 	public function __construct( string $assets_folder = 'build/views/' ) {
 		$this->assets_path     = trailingslashit( UCSC_DIR ) . $assets_folder;
 		$this->assets_path_uri = trailingslashit( UCSC_PLUGIN_URL ) . $assets_folder;
 	}
 
+	/**
+	 * Enqueue the stylesheet and script for every registered UCSC block.
+	 *
+	 * Version and dependencies come from each block's generated asset file.
+	 *
+	 * Note: the style handle is suffixed per block, but the script handle is
+	 * not — every block enqueues its script under the same $handle_file, so
+	 * only the first one registered actually loads. Tracked in #102; left
+	 * as-is here so this stays a documentation-only change.
+	 *
+	 * @param string $assets_file Filename of the generated asset manifest, e.g. index.asset.php.
+	 * @param string $handle_file Script handle, also used as the .js basename.
+	 * @param string $css_handle  Stylesheet handle, also used as the .css basename.
+	 *
+	 * @return void
+	 */
 	public function register( string $assets_file, string $handle_file, string $css_handle ): void {
 		$ucsc_custom_blocks = array_filter(
 			\WP_Block_Type_Registry::get_instance()->get_all_registered(),

--- a/src/Assets/Assets_Subscriber.php
+++ b/src/Assets/Assets_Subscriber.php
@@ -1,9 +1,31 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Asset hook registration.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Assets;
 
+/**
+ * Wires the asset enqueuers to their WordPress hooks.
+ *
+ * Also attaches the two standalone stylesheets that style *core* blocks rather
+ * than UCSC ones; those are compiled from assets/scss/blocks/ by extra webpack
+ * entries and have no block.json of their own.
+ */
 class Assets_Subscriber {
 
+	/**
+	 * Register the enqueue hooks and the core-block stylesheets.
+	 *
+	 * Public assets load on both the front end and in wp-admin; editor assets
+	 * load only in the block editor.
+	 *
+	 * @return void
+	 */
 	public function register(): void {
 		add_action(
 			'wp_enqueue_scripts',

--- a/src/Assets/Editor_Assets_Enqueuer.php
+++ b/src/Assets/Editor_Assets_Enqueuer.php
@@ -1,10 +1,37 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Block editor assets.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Assets;
 
+/**
+ * Names the built files that make up a block's editor assets.
+ */
 class Editor_Assets_Enqueuer extends Assets_Enqueuer {
 
-	public const EDITOR           = 'index';
+	/**
+	 * Script and stylesheet handle. Passed for both by the subscriber.
+	 *
+	 * @var string
+	 */
+	public const EDITOR = 'index';
+
+	/**
+	 * Built file basename.
+	 *
+	 * @var string
+	 */
 	public const EDITOR_FILE_NAME = 'index';
-	public const ASSETS_FILE      = self::EDITOR_FILE_NAME . '.asset.php';
+
+	/**
+	 * Generated asset manifest filename.
+	 *
+	 * @var string
+	 */
+	public const ASSETS_FILE = self::EDITOR_FILE_NAME . '.asset.php';
 }

--- a/src/Assets/Public_Assets_Enqueuer.php
+++ b/src/Assets/Public_Assets_Enqueuer.php
@@ -1,10 +1,37 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Front-end block assets.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Assets;
 
+/**
+ * Names the built files that make up a block's front-end assets.
+ */
 class Public_Assets_Enqueuer extends Assets_Enqueuer {
 
-	public const PUBLIC      = 'index';
-	public const PUBLIC_CSS  = 'style-index';
+	/**
+	 * Script handle and .js basename.
+	 *
+	 * @var string
+	 */
+	public const PUBLIC = 'index';
+
+	/**
+	 * Stylesheet handle and .css basename.
+	 *
+	 * @var string
+	 */
+	public const PUBLIC_CSS = 'style-index';
+
+	/**
+	 * Generated asset manifest filename.
+	 *
+	 * @var string
+	 */
 	public const ASSETS_FILE = self::PUBLIC . '.asset.php';
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Plugin bootstrap.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks;
 
@@ -21,14 +28,48 @@ use UCSC\Blocks\Template\Photo_Of_The_Week_Archive;
 use UCSC\Blocks\Template\Post_Single;
 use UCSC\Blocks\Template\Template_Subscriber;
 
+/**
+ * Singleton bootstrap and block registry.
+ *
+ * Instantiated from plugin.php on plugins_loaded (priority 100), and only when
+ * ACF PRO is active. Nothing in src/ runs without it.
+ *
+ * Registration is split in two: BLOCKS_PUBLIC loads everywhere, while
+ * BLOCKS_NEWS_ONLY, the custom post type, templates and subscribers load only
+ * when UCSC_NEWS_SITE is defined true.
+ */
 class Core {
 
+	/**
+	 * Registry key for the Photos of the Week query loop.
+	 *
+	 * Unlike its siblings this is a plain string rather than a class constant,
+	 * because the block has no field-group class to instantiate.
+	 *
+	 * @var string
+	 */
 	public const PHOTOS_LOOP = 'photos-week-loop';
 
+	/**
+	 * Blocks registered on every site.
+	 *
+	 * Maps a field-group class to its build directory. The path must match the
+	 * src/views/ directory name, since webpack mirrors the source directory
+	 * rather than the block.json slug. A mismatch silently skips registration.
+	 *
+	 * @var array<string, string>
+	 */
 	public const BLOCKS_PUBLIC = [
 		News_Block::class => '/build/views/news-block',
 	];
 
+	/**
+	 * Blocks registered only when UCSC_NEWS_SITE is true.
+	 *
+	 * Same path contract as BLOCKS_PUBLIC.
+	 *
+	 * @var array<string, string>
+	 */
 	public const BLOCKS_NEWS_ONLY = [
 		self::PHOTOS_LOOP              => '/build/views/photos-week-loop',
 		Photo_Of_The_Week_Block::class => '/build/views/photo-of-the-week-block',
@@ -40,8 +81,18 @@ class Core {
 		Post_Header_Block::class       => '/build/views/post-header-block',
 	];
 
+	/**
+	 * The single instance.
+	 *
+	 * @var self
+	 */
 	private static self $instance;
 
+	/**
+	 * Get the singleton instance, creating it on first call.
+	 *
+	 * @return self
+	 */
 	public static function instance(): self {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new self();
@@ -50,6 +101,14 @@ class Core {
 		return self::$instance;
 	}
 
+	/**
+	 * Register everything the plugin provides.
+	 *
+	 * Each step hooks its own WordPress action, so ordering here reflects
+	 * grouping rather than execution order.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 		$this->blocks();
 		$this->scripts();
@@ -60,11 +119,20 @@ class Core {
 	}
 
 	/**
+	 * Render an ACF block by including its view template.
+	 *
+	 * Registered as the render_callback for every block. The stored path points
+	 * into build/, but the PHP template is read from src/ so that view edits
+	 * take effect without a rebuild; the index.php copied into build/ is never
+	 * executed.
+	 *
 	 * @param array          $block      The block attributes.
 	 * @param string         $content    The block content.
 	 * @param bool           $is_preview Whether the block is being rendered for editing preview.
 	 * @param int            $post_id    The current post being edited or viewed.
 	 * @param \WP_Block|null $wp_block   The block instance (since WP 5.5).
+	 *
+	 * @return void
 	 */
 	public function render_template( array $block, string $content = '', bool $is_preview = false, int $post_id = 0, ?\WP_Block $wp_block = null ): void {
 		$template = $block['render_template'];
@@ -77,6 +145,14 @@ class Core {
 		include "$path/$template"; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 	}
 
+	/**
+	 * Inject the custom block templates on news sites.
+	 *
+	 * Deferred to after_setup_theme because the templates are tied to a
+	 * wp_theme term and need the active theme resolved first.
+	 *
+	 * @return void
+	 */
 	protected function templates(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
@@ -99,6 +175,14 @@ class Core {
 		);
 	}
 
+	/**
+	 * Register the news-site event subscribers.
+	 *
+	 * Query modifications, third-party integrations and core-block output
+	 * filtering. All are news-only.
+	 *
+	 * @return void
+	 */
 	protected function subscribers(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
@@ -108,6 +192,11 @@ class Core {
 		( new Template_Subscriber() )->init();
 	}
 
+	/**
+	 * Register the custom object meta fields. News sites only.
+	 *
+	 * @return void
+	 */
 	protected function object_meta(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
@@ -116,6 +205,11 @@ class Core {
 		( new Object_Meta_Definer() )->register();
 	}
 
+	/**
+	 * Register the Photo of the Week post type. News sites only.
+	 *
+	 * @return void
+	 */
 	protected function post_types(): void {
 		if ( ! $this->is_news_site() ) {
 			return;
@@ -131,6 +225,14 @@ class Core {
 		);
 	}
 
+	/**
+	 * Register blocks and their editor hooks on init.
+	 *
+	 * The News block and its hooks register everywhere; the taxonomy hooks are
+	 * news-only.
+	 *
+	 * @return void
+	 */
 	protected function blocks(): void {
 		add_action(
 			'init',
@@ -150,6 +252,14 @@ class Core {
 		);
 	}
 
+	/**
+	 * Enqueue the editor-side helper scripts.
+	 *
+	 * The News block script loads on every site; the custom-blocks script is
+	 * news-only.
+	 *
+	 * @return void
+	 */
 	protected function scripts(): void {
 		add_action(
 			'admin_enqueue_scripts',
@@ -181,6 +291,15 @@ class Core {
 		);
 	}
 
+	/**
+	 * Register each block from its build-directory block.json.
+	 *
+	 * Every block shares one render_callback; the template is resolved per
+	 * block from the metadata. Field-group classes are instantiated after
+	 * registration so their ACF fields attach to the registered block name.
+	 *
+	 * @return void
+	 */
 	protected function init_blocks(): void {
 		$args = [
 			'render_callback' => [ $this, 'render_template' ],
@@ -204,6 +323,13 @@ class Core {
 		}
 	}
 
+	/**
+	 * Whether this install is the news site.
+	 *
+	 * Single gate for every news-only feature.
+	 *
+	 * @return bool
+	 */
 	private function is_news_site(): bool {
 		return defined( 'UCSC_NEWS_SITE' ) && UCSC_NEWS_SITE;
 	}

--- a/src/Hooks/News_Blocks_Hooks.php
+++ b/src/Hooks/News_Blocks_Hooks.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * News block editor field hooks.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Hooks;
 
@@ -6,22 +13,53 @@ use UCSC\Blocks\Blocks\News_Block;
 use UCSC\Blocks\Request\News_Request;
 use UCSC\Blocks\Traits\With_Get_Field_Key;
 
+/**
+ * Populates the News block's taxonomy and term dropdowns from the news site.
+ *
+ * Unlike Taxonomies_Hooks, which reads local taxonomies, every choice here is
+ * fetched over REST from the remote news site. Responses are cached in
+ * transients for 20 minutes, keyed by composed field key — so when the editor
+ * dropdowns look stale, those transients are what to delete.
+ */
 class News_Blocks_Hooks {
 
 	use With_Get_Field_Key;
 
+	/**
+	 * Client for the news site's REST API.
+	 *
+	 * @var News_Request
+	 */
 	private News_Request $request;
 
+	/**
+	 * Set up the remote request client.
+	 */
 	public function __construct() {
 		$this->request = new News_Request();
 	}
 
+	/**
+	 * Register the ACF load and search filters for the News block.
+	 *
+	 * @return void
+	 */
 	public function hooks(): void {
 		add_filter( 'acf/load_field/name=' . News_Block::TAXONOMIES, [ $this, 'load_taxonomies' ] );
 		add_filter( 'acf/load_field/name=' . News_Block::TAX_ITEMS, [ $this, 'load_tax_items' ] );
 		add_filter( 'acf/fields/select/query/key=' . $this->get_field_key( News_Block::TAX_ITEMS, News_Block::NAME ), [ $this, 'load_search_tax_items' ] );
 	}
 
+	/**
+	 * Fill the taxonomy dropdown from the news site.
+	 *
+	 * Only taxonomies listed in News_Block::ALLOWED_TAX are offered. Choices
+	 * are keyed by REST base, since that is what the posts query needs.
+	 *
+	 * @param array $field The ACF field definition.
+	 *
+	 * @return array The field, with its choices populated.
+	 */
 	public function load_taxonomies( array $field ): array {
 		$choices = get_transient( $this->get_field_key( News_Block::TAXONOMIES, News_Block::NAME ) );
 
@@ -53,6 +91,15 @@ class News_Blocks_Hooks {
 		return $field;
 	}
 
+	/**
+	 * Fill the term dropdown for the selected remote taxonomy.
+	 *
+	 * Falls back to 'categories' when nothing has been chosen yet.
+	 *
+	 * @param array $field The ACF field definition.
+	 *
+	 * @return array The field, with its choices populated.
+	 */
 	public function load_tax_items( array $field ): array {
 		$selected_tax = get_field( News_Block::TAXONOMIES );
 
@@ -75,6 +122,20 @@ class News_Blocks_Hooks {
 		return $field;
 	}
 
+	/**
+	 * Answer the editor's AJAX term search against the remote taxonomy.
+	 *
+	 * Filters the cached choice list in PHP rather than querying the news site
+	 * per keystroke.
+	 *
+	 * Note: $_POST['taxonomy_selected'] is read without isset(), wp_unslash()
+	 * or sanitisation, and is concatenated into both the outbound REST path and
+	 * the transient key. Tracked in #103.
+	 *
+	 * @param mixed $shortcut The response ACF will return, if short-circuited.
+	 *
+	 * @return mixed The response, with matching terms as results.
+	 */
 	public function load_search_tax_items( $shortcut ) {
 		if ( ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			return $shortcut;
@@ -118,6 +179,13 @@ class News_Blocks_Hooks {
 		return $shortcut;
 	}
 
+	/**
+	 * Fetch every term of a remote taxonomy, following pagination.
+	 *
+	 * @param string $type The taxonomy's REST base.
+	 *
+	 * @return array Term names keyed by remote term ID, or an empty array on failure.
+	 */
 	protected function get_taxonomies_item_by_type( string $type = 'categories' ): array {
 		$response = $this->request->request( News_Request::ENDPOINT_BASE . $type, [ 'per_page' => 100 ], true );
 

--- a/src/Hooks/Taxonomies_Hooks.php
+++ b/src/Hooks/Taxonomies_Hooks.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Taxonomy field hooks for the block editor.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Hooks;
 
@@ -6,10 +13,25 @@ use UCSC\Blocks\Blocks\Contracts\Taxonomies;
 use UCSC\Blocks\Blocks\Featured_News_Block;
 use UCSC\Blocks\Traits\With_Get_Field_Key;
 
+/**
+ * Populates the taxonomy and term dropdowns on query-loop blocks.
+ *
+ * The choices cannot be declared statically in the field group because they
+ * depend on what is registered on the site and on what the editor has already
+ * selected, so they are filled in through ACF load filters at edit time.
+ */
 class Taxonomies_Hooks {
 
 	use With_Get_Field_Key;
 
+	/**
+	 * Taxonomies hidden from the editor's taxonomy dropdown.
+	 *
+	 * These are WordPress internals — menus, templates, patterns — that are
+	 * registered as taxonomies but are not editorial classifications.
+	 *
+	 * @var string[]
+	 */
 	public const RESTRICTED_TAXONOMIES = [
 		'nav_menu',
 		'link_category',
@@ -20,6 +42,14 @@ class Taxonomies_Hooks {
 		'author',
 	];
 
+	/**
+	 * Register the ACF load and search filters.
+	 *
+	 * The select-search filter is keyed by composed field key, so it only
+	 * applies to the specific field it names.
+	 *
+	 * @return void
+	 */
 	public function hooks(): void {
 		add_filter( 'acf/load_field/name=' . Taxonomies::TAXONOMIES, [ $this, 'load_taxonomies' ] );
 		add_filter( 'acf/load_field/name=' . Taxonomies::TAX_ITEMS, [ $this, 'load_tax_items' ] );
@@ -33,6 +63,13 @@ class Taxonomies_Hooks {
 		}
 	}
 
+	/**
+	 * Fill the taxonomy dropdown with the site's public taxonomies.
+	 *
+	 * @param array $field The ACF field definition.
+	 *
+	 * @return array The field, with its choices populated.
+	 */
 	public function load_taxonomies( array $field ): array {
 		$taxonomies = get_taxonomies( [], false );
 
@@ -41,6 +78,8 @@ class Taxonomies_Hooks {
 		}
 
 		/**
+		 * Registered taxonomy objects, keyed by name.
+		 *
 		 * @var \WP_Taxonomy[] $taxonomies
 		 */
 		foreach ( $taxonomies as $key => $taxonomy ) {
@@ -54,6 +93,16 @@ class Taxonomies_Hooks {
 		return $field;
 	}
 
+	/**
+	 * Fill the term dropdown for the currently selected taxonomy.
+	 *
+	 * Falls back to 'category' when no taxonomy has been chosen yet, so the
+	 * field is never empty on a freshly inserted block.
+	 *
+	 * @param array $field The ACF field definition.
+	 *
+	 * @return array The field, with its choices populated.
+	 */
 	public function load_tax_items( array $field ): array {
 		$selected_tax = get_field( Taxonomies::TAXONOMIES );
 
@@ -73,6 +122,8 @@ class Taxonomies_Hooks {
 		}
 
 		/**
+		 * Matching terms.
+		 *
 		 * @var \WP_Term[] $terms
 		 */
 		foreach ( $terms as $term ) {
@@ -82,6 +133,20 @@ class Taxonomies_Hooks {
 		return $field;
 	}
 
+	/**
+	 * Answer the editor's AJAX term search.
+	 *
+	 * Runs only during an AJAX request; otherwise the value is passed straight
+	 * through so ACF performs its normal query.
+	 *
+	 * Note: $_POST['taxonomy_selected'] is read without isset(), wp_unslash()
+	 * or sanitisation. WordPress validates the taxonomy argument so the impact
+	 * is limited, but the missing guards are tracked in #103.
+	 *
+	 * @param mixed $shortcut The response ACF will return, if short-circuited.
+	 *
+	 * @return mixed The response, with matching terms as results.
+	 */
 	public function load_search_tax_items( $shortcut ) {
 		if ( ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			return $shortcut;
@@ -108,6 +173,8 @@ class Taxonomies_Hooks {
 		}
 
 		/**
+		 * Matching terms.
+		 *
 		 * @var \WP_Term[] $terms
 		 */
 		foreach ( $terms as $term ) {

--- a/src/Integrations/ACF_Toolbars.php
+++ b/src/Integrations/ACF_Toolbars.php
@@ -1,11 +1,33 @@
 <?php
+/**
+ * ACF WYSIWYG toolbar definitions.
+ *
+ * @package ucsc
+ */
 
 namespace UCSC\Blocks\Integrations;
 
+/**
+ * Defines the cut-down WYSIWYG toolbars offered to editors.
+ */
 class ACF_Toolbars {
 
+	/**
+	 * Toolbar name, as selected on an ACF WYSIWYG field.
+	 *
+	 * @var string
+	 */
 	public const SIMPLE = 'ucsc_simple_toolbar';
 
+	/**
+	 * Add a minimal toolbar offering only bold, italic and link.
+	 *
+	 * Used for fields where richer formatting would break the block's layout.
+	 *
+	 * @param array $toolbars Toolbars registered so far.
+	 *
+	 * @return array The toolbars, with the simple one added.
+	 */
 	public function register_simple_toolbar( array $toolbars ): array {
 		$toolbars[ self::SIMPLE ]    = [];
 		$toolbars[ self::SIMPLE ][1] = [ 'bold', 'italic', 'link' ];

--- a/src/Integrations/Integrations_Subscriber.php
+++ b/src/Integrations/Integrations_Subscriber.php
@@ -1,9 +1,28 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Third-party plugin integrations.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Integrations;
 
+/**
+ * Registers integrations with Yoast SEO and ACF.
+ */
 class Integrations_Subscriber {
 
+	/**
+	 * Taxonomies intended to support a Yoast primary term.
+	 *
+	 * Note: only 'academics' is actually registered — the loop in init()
+	 * ignores its own iteration variable. Tracked in #105; left as-is here so
+	 * this stays a documentation-only change.
+	 *
+	 * @var string[]
+	 */
 	public const PRIMARY_TAX_SUPPORT = [
 		'academics',
 		'administration',
@@ -12,6 +31,11 @@ class Integrations_Subscriber {
 		'kind',
 	];
 
+	/**
+	 * Register the Yoast primary-term and ACF toolbar filters.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 		add_filter(
 			'wpseo_primary_term_taxonomies',

--- a/src/Object_Meta/Object_Meta_Definer.php
+++ b/src/Object_Meta/Object_Meta_Definer.php
@@ -1,9 +1,27 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Object meta registration.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Object_Meta;
 
+/**
+ * Registers the plugin's custom object meta on init.
+ */
 class Object_Meta_Definer {
 
+	/**
+	 * Register every meta definition.
+	 *
+	 * Deferred to init because register_post_meta() requires the post type to
+	 * exist first.
+	 *
+	 * @return void
+	 */
 	public function register(): void {
 		add_action(
 			'init',

--- a/src/Object_Meta/Photo_Of_The_Week_Meta.php
+++ b/src/Object_Meta/Photo_Of_The_Week_Meta.php
@@ -1,17 +1,51 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week meta fields.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Object_Meta;
 
 use UCSC\Blocks\Blocks\ACF_Group;
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
+/**
+ * ACF field group attached to the Photo of the Week post type.
+ *
+ * Supplies the photograph itself and its credit; the post title carries the
+ * caption.
+ */
 class Photo_Of_The_Week_Meta extends ACF_Group {
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'photo_of_the_week_post';
 
+	/**
+	 * Photographer credit field name.
+	 *
+	 * @var string
+	 */
 	public const PHOTOGRAPHER = 'photographer';
-	public const IMAGE        = 'image';
 
+	/**
+	 * Image field name.
+	 *
+	 * @var string
+	 */
+	public const IMAGE = 'image';
+
+	/**
+	 * Attach the group to the Photo of the Week post type.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -24,14 +58,29 @@ class Photo_Of_The_Week_Meta extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Field group title, shown in the editor.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Photo of the Week', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The fields in this group.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_photographer(),
@@ -39,6 +88,11 @@ class Photo_Of_The_Week_Meta extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Photographer credit. Plain text.
+	 *
+	 * @return array
+	 */
 	protected function get_photographer(): array {
 		return [
 			'label' => esc_html__( 'Photographer', 'ucsc' ),
@@ -48,6 +102,11 @@ class Photo_Of_The_Week_Meta extends ACF_Group {
 		];
 	}
 
+	/**
+	 * The photograph. Required; returned as an array.
+	 *
+	 * @return array
+	 */
 	protected function get_image(): array {
 		return [
 			'label'         => esc_html__( 'Image', 'ucsc' ),

--- a/src/Post_Types/Photo_Of_The_Week/Photo_Of_The_Week.php
+++ b/src/Post_Types/Photo_Of_The_Week/Photo_Of_The_Week.php
@@ -1,13 +1,40 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week post type.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Post_Types\Photo_Of_The_Week;
 
 use UCSC\Blocks\Post_Types\Post_Types;
 
+/**
+ * The Photo of the Week custom post type. News sites only.
+ *
+ * Individual photos have no standalone page — Query_Subscriber redirects
+ * single views to the archive — so the type exists to populate the archive
+ * template and the Photos of the Week block.
+ */
 class Photo_Of_The_Week extends Post_Types {
 
+	/**
+	 * The post type slug.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'photo_of_the_week';
 
+	/**
+	 * Arguments passed to register_post_type().
+	 *
+	 * Registers an archive under the 'photo-of-the-week' rewrite slug and
+	 * supports only a title; the photograph and credit come from ACF meta.
+	 *
+	 * @return array
+	 */
 	public function get_args(): array {
 		return [
 			'labels'          => $this->get_labels(),
@@ -27,6 +54,11 @@ class Photo_Of_The_Week extends Post_Types {
 		];
 	}
 
+	/**
+	 * Admin-facing labels for the post type.
+	 *
+	 * @return array
+	 */
 	protected function get_labels(): array {
 		return [
 			'name'         => esc_html__( 'Photo of the Week', 'ucsc' ),

--- a/src/Post_Types/Post_Types.php
+++ b/src/Post_Types/Post_Types.php
@@ -1,13 +1,43 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Custom post type base class.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Post_Types;
 
+/**
+ * Base for the plugin's custom post types.
+ *
+ * Subclasses supply the post type slug and its registration arguments.
+ */
 abstract class Post_Types {
 
+	/**
+	 * The post type slug. Overridden by each subclass.
+	 *
+	 * @var string
+	 */
 	public const NAME = '';
 
+	/**
+	 * Arguments passed to register_post_type().
+	 *
+	 * @return array
+	 */
 	abstract public function get_args(): array;
 
+	/**
+	 * Register the post type.
+	 *
+	 * Must run on init. Note that nothing flushes rewrite rules, so a new post
+	 * type's permalinks 404 until they are re-saved; tracked in #108.
+	 *
+	 * @return void
+	 */
 	public function register(): void {
 		register_post_type( static::NAME, $this->get_args() );
 	}

--- a/src/Query/Query_Subscriber.php
+++ b/src/Query/Query_Subscriber.php
@@ -1,11 +1,30 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Query and routing modifications.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Query;
 
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
+/**
+ * Adjusts front-end routing for news-site content types.
+ */
 class Query_Subscriber {
 
+	/**
+	 * Redirect single Photo of the Week views to the archive.
+	 *
+	 * The post type exists to populate the archive and the block; individual
+	 * photos have no standalone page, so a direct hit is bounced rather than
+	 * rendering an empty single template.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 		add_action(
 			'template_redirect',

--- a/src/Request/News_Request.php
+++ b/src/Request/News_Request.php
@@ -1,16 +1,77 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Remote REST client for the news site.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Request;
 
+/**
+ * Fetches content from the news site's REST API.
+ *
+ * This is the one place the plugin reaches outside the current install: the
+ * News block renders posts pulled from news.ucsc.edu rather than the local
+ * database. The base URL is chosen from the environment type, so a staging
+ * install reads from the staging news site.
+ */
 class News_Request {
 
+	/**
+	 * Taxonomies endpoint, relative to the environment base URL.
+	 *
+	 * @var string
+	 */
 	public const TAXONOMY_ENDPOINT = 'wp-json/wp/v2/taxonomies';
-	public const POSTS_ENDPOINT    = 'wp-json/wp/v2/posts';
-	public const ENDPOINT_BASE     = 'wp-json/wp/v2/';
 
+	/**
+	 * Posts endpoint, relative to the environment base URL.
+	 *
+	 * @var string
+	 */
+	public const POSTS_ENDPOINT = 'wp-json/wp/v2/posts';
+
+	/**
+	 * REST namespace prefix, for callers composing their own endpoint path.
+	 *
+	 * @var string
+	 */
+	public const ENDPOINT_BASE = 'wp-json/wp/v2/';
+
+	/**
+	 * Results accumulated across paginated requests.
+	 *
+	 * @var array
+	 */
 	private array $data = [];
-	private int $page   = 1;
 
+	/**
+	 * Page currently being fetched.
+	 *
+	 * @var int
+	 */
+	private int $page = 1;
+
+	/**
+	 * Fetch a REST endpoint, optionally following pagination.
+	 *
+	 * With $with_pagination the method recurses, accumulating every page into
+	 * $data before returning. Any non-2xx response or thrown error yields an
+	 * empty array, so a failed fetch renders an empty block rather than an
+	 * error.
+	 *
+	 * Note: no explicit timeout is set, and the pagination recursion has no
+	 * page cap, so a slow or very large response can stall a page render.
+	 * Both are tracked in #107.
+	 *
+	 * @param string $endpoint        Endpoint path, relative to the environment base URL.
+	 * @param array  $args            Query arguments to append.
+	 * @param bool   $with_pagination Whether to follow X-WP-TotalPages and fetch every page.
+	 *
+	 * @return array The decoded response body, or an empty array on failure.
+	 */
 	public function request( string $endpoint, array $args = [], bool $with_pagination = false ): array {
 		try {
 			$url           = add_query_arg( $args, $this->get_endpoint_url( $endpoint ) );
@@ -51,6 +112,16 @@ class News_Request {
 		}
 	}
 
+	/**
+	 * Resolve an endpoint path against the environment's news site.
+	 *
+	 * Production and any unrecognised environment read from the live site;
+	 * staging and development read from their Pantheon counterparts.
+	 *
+	 * @param string $endpoint Endpoint path, relative to the base URL.
+	 *
+	 * @return string The absolute endpoint URL.
+	 */
 	protected function get_endpoint_url( string $endpoint ): string {
 		$env = wp_get_environment_type();
 

--- a/src/Traits/With_Get_Field_Key.php
+++ b/src/Traits/With_Get_Field_Key.php
@@ -1,9 +1,31 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * ACF field key composition.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Traits;
 
+/**
+ * Composes ACF field keys from a field name and its group name.
+ */
 trait With_Get_Field_Key {
 
+	/**
+	 * Build the ACF field key for a field within a group.
+	 *
+	 * The result is "{group}_{name}". ACF filters that target a specific field
+	 * by key — the "acf/fields/.../query/key=" hooks in src/Hooks/ — depend on
+	 * this exact composition, so changing the format breaks them silently.
+	 *
+	 * @param string $name       The field name, normally a class constant.
+	 * @param string $group_name The owning field group's name.
+	 *
+	 * @return string The composed field key.
+	 */
 	public function get_field_key( string $name, string $group_name ): string {
 		return sprintf( '%s_%s', $group_name, $name );
 	}


### PR DESCRIPTION
## What does this do/fix?

Step 3 of #116, **slice 1 of 4** — the plugin entry point, `Core`, and the supporting infrastructure directories.

**phpcs: 550 errors → 446.** 24 files.

Covers `plugin.php`, `lib/functions/`, `src/Core.php`, `src/Assets/`, `src/Hooks/`, `src/Object_Meta/`, `src/Post_Types/`, `src/Request/`, `src/Query/`, `src/Integrations/`, `src/Traits/`.

Starting here because the file- and class-level docs set the conventions the remaining slices follow, and because `Core` is the file a newcomer reads first.

### Remaining slices

| slice | scope | count |
|---|---|---|
| ~~1~~ | ~~bootstrap + infrastructure~~ | ~~103~~ ✅ |
| 2 | `src/Blocks/` | 117 |
| 3 | `src/Components/` | 125 |
| 4 | `src/Template/` + `src/views/` | 51 |

## Docblocks name open bugs rather than blessing them

Several of these functions currently misbehave. A docblock that describes the behaviour neutrally would quietly certify the bug as intended, so each one points at its issue instead:

| location | note | issue |
|---|---|---|
| `Assets_Enqueuer::register()` | script handle not suffixed per block | #102 |
| `Integrations_Subscriber::PRIMARY_TAX_SUPPORT` | only `academics` is registered | #105 |
| `News_Request::request()` | no timeout, no pagination cap | #107 |
| `Post_Types::register()` | no rewrite flush | #108 |
| `*_Hooks::load_search_tax_items()` | unsanitised `$_POST` | #103 |
| `ga.php`, `site-improve.php` | hardcoded tracking IDs | #113 |

Nothing was fixed here — this stays documentation-only so it can be reviewed as prose.

## One structural change

Several files opened with `<?php declare(strict_types=1);` on a single line. That makes the following docblock *not* a file comment as far as phpcs is concerned, so `Squiz.Commenting.FileComment.Missing` could not be satisfied by adding one.

`declare()` now sits on its own line beneath the docblock:

```php
<?php
/**
 * ...
 *
 * @package ucsc
 */

declare(strict_types=1);
```

It remains the first *statement* in the file — comments don't count — so strict types still apply. The `declare(strict_types=1)` convention from CLAUDE.md is unchanged.

## Tests

```bash
composer lint    # 446 errors, down from 550
npm run build    # green
```

Verified locally:

- [x] All 24 changed files pass `php -l`
- [x] Zero documentation violations remain in every directory in this slice
- [x] **Documentation-only**: token streams compared with comments stripped and open-tag whitespace normalised — executable code identical across all 24 files
- [x] `npm run build` green

Reviewer checks — this is prose, so it wants reading rather than running:

- [ ] The claims in `Core.php` match your understanding of the bootstrap order
- [ ] The issue cross-references above are accurate and not overstated
- [ ] `News_Request` — the environment-to-URL mapping description is correct
- [ ] Nothing reads as confidently wrong; a misleading docblock is worse than none

Two footguns worth knowing about, both of which bit me while writing this and are now avoided in the source: a `*/` inside a block comment (from writing an `acf/fields/*/query` path) terminates it early, and `?>` inside a `//` comment exits PHP mode entirely.
