### PR TITLE
docs: add docblocks to block field groups (slice 2/4)

### DIFF
--- a/src/Blocks/ACF_Group.php
+++ b/src/Blocks/ACF_Group.php
@@ -1,23 +1,78 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * ACF field group base class.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Traits\With_Get_Field_Key;
 
+/**
+ * Base for every ACF field group the plugin registers.
+ *
+ * Each block is three coordinated pieces: this field group defines what the
+ * editor sees, a controller in src/Components/ reads the saved values, and a
+ * view in src/views/ renders them. Subclasses supply the four abstract methods
+ * and are instantiated by Core after the block itself is registered.
+ *
+ * Field *names* are declared as constants on the subclass and referenced by
+ * both the group and its controller, so the two never drift apart.
+ */
 abstract class ACF_Group {
 
 	use With_Get_Field_Key;
 
+	/**
+	 * Whether this group should register.
+	 *
+	 * Lets a subclass opt out without being removed from Core's registry.
+	 *
+	 * @var bool
+	 */
 	public bool $enabled = true;
 
+	/**
+	 * Where the group appears, as ACF location rules.
+	 *
+	 * For blocks this is a single 'block' rule naming the registered block.
+	 *
+	 * @return array
+	 */
 	abstract protected function get_locations(): array;
 
+	/**
+	 * The group's title, shown in the editor sidebar.
+	 *
+	 * @return string
+	 */
 	abstract protected function get_title(): string;
 
+	/**
+	 * The group's ACF key.
+	 *
+	 * Field keys are composed from this via get_field_key(), so it must stay
+	 * stable — changing it orphans every value already saved against it.
+	 *
+	 * @return string
+	 */
 	abstract protected function get_key(): string;
 
+	/**
+	 * The group's field definitions.
+	 *
+	 * @return array
+	 */
 	abstract protected function get_fields(): array;
 
+	/**
+	 * Register the field group with ACF.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 		if ( ! $this->enabled ) {
 			return;
@@ -26,6 +81,11 @@ abstract class ACF_Group {
 		acf_add_local_field_group( $this->get_group_args() );
 	}
 
+	/**
+	 * Assemble the arguments for acf_add_local_field_group().
+	 *
+	 * @return array
+	 */
 	protected function get_group_args(): array {
 		return [
 			'key'                   => $this->get_key(),

--- a/src/Blocks/Contracts/CTA_Field.php
+++ b/src/Blocks/Contracts/CTA_Field.php
@@ -1,10 +1,34 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Call-to-action field contract.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks\Contracts;
 
+/**
+ * Implemented by field groups offering a call-to-action link.
+ */
 interface CTA_Field {
 
+	/**
+	 * Default field name for the call to action.
+	 *
+	 * @var string
+	 */
 	public const CTA = 'cta';
 
+	/**
+	 * The call-to-action link field definition.
+	 *
+	 * @param string $group_name The owning group name, used to compose the field key.
+	 * @param string $label      Editor-facing label.
+	 * @param string $name       Field name; defaults to self::CTA when empty.
+	 *
+	 * @return array
+	 */
 	public function get_cta_field( string $group_name, string $label, string $name = '' ): array;
 }

--- a/src/Blocks/Contracts/Taxonomies.php
+++ b/src/Blocks/Contracts/Taxonomies.php
@@ -1,13 +1,54 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Taxonomy field contract.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks\Contracts;
 
+/**
+ * Implemented by field groups offering a taxonomy and term picker.
+ *
+ * The field names are shared constants because the ACF load filters in
+ * src/Hooks/ target them by name; a group that renames them silently loses
+ * its editor dropdowns.
+ */
 interface Taxonomies {
 
+	/**
+	 * Field name of the taxonomy selector.
+	 *
+	 * @var string
+	 */
 	public const TAXONOMIES = 'taxonomies_list';
-	public const TAX_ITEMS  = 'taxonomy_list_items';
 
+	/**
+	 * Field name of the term selector.
+	 *
+	 * @var string
+	 */
+	public const TAX_ITEMS = 'taxonomy_list_items';
+
+	/**
+	 * The taxonomy selector field definition.
+	 *
+	 * Choices are filled in at edit time by the hooks, not declared here.
+	 *
+	 * @param string $name The owning group name.
+	 *
+	 * @return array
+	 */
 	public function get_taxonomies_list( string $name ): array;
 
+	/**
+	 * The term selector field definition.
+	 *
+	 * @param string $name The owning group name.
+	 *
+	 * @return array
+	 */
 	public function get_taxonomies_items( string $name ): array;
 }

--- a/src/Blocks/Featured_News_Block.php
+++ b/src/Blocks/Featured_News_Block.php
@@ -1,20 +1,52 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Featured news block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Blocks\Contracts\CTA_Field;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
+/**
+ * Field group for the Featured Stories block.
+ *
+ * A query-loop block with an added call-to-action link.
+ */
 class Featured_News_Block extends Query_Loop implements CTA_Field {
 
 	use With_CTA_Field;
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_featured_news_block';
 
+	/**
+	 * Call-to-action field name.
+	 *
+	 * @var string
+	 */
 	public const CTA_FIELD = 'featured_cta';
 
+	/**
+	 * Label for a single card in manual mode.
+	 *
+	 * @var string
+	 */
 	protected string $default_manual_card_label = 'Article';
 
+	/**
+	 * Attach the group to the Featured News block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -27,14 +59,29 @@ class Featured_News_Block extends Query_Loop implements CTA_Field {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Featured Stories', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The query selection fields plus an all-news link.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_query_loop_group( self::NAME ),

--- a/src/Blocks/Magazine_Block.php
+++ b/src/Blocks/Magazine_Block.php
@@ -1,26 +1,94 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Magazine block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
+/**
+ * Field group for the UCSC Magazine block.
+ *
+ * A two-line masthead above a repeater of magazine items, each rendered as
+ * a tab with its own image, byline, description and call to action.
+ */
 class Magazine_Block extends ACF_Group {
 
 	use With_CTA_Field;
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_magazine_block';
 
+	/**
+	 * First masthead line, rendered light.
+	 *
+	 * @var string
+	 */
 	public const TITLE_LINE_1 = 'title_1';
+	/**
+	 * Second masthead line, rendered bold.
+	 *
+	 * @var string
+	 */
 	public const TITLE_LINE_2 = 'title_2';
-	public const SUBTITLE     = 'subtitle';
-	public const ITEMS        = 'items';
-	public const ITEM_TITLE   = 'item_title';
-	public const ITEM_BYLINE  = 'item_byline';
-	public const ITEM_IMAGE   = 'item_image';
-	public const ITEM_DESC    = 'item_description';
+	/**
+	 * Subtitle field name.
+	 *
+	 * @var string
+	 */
+	public const SUBTITLE = 'subtitle';
+	/**
+	 * Repeater field name holding the magazine items.
+	 *
+	 * @var string
+	 */
+	public const ITEMS = 'items';
+	/**
+	 * Item title field name. Also the collapsed-row label.
+	 *
+	 * @var string
+	 */
+	public const ITEM_TITLE = 'item_title';
+	/**
+	 * Item byline field name.
+	 *
+	 * @var string
+	 */
+	public const ITEM_BYLINE = 'item_byline';
+	/**
+	 * Item image field name.
+	 *
+	 * @var string
+	 */
+	public const ITEM_IMAGE = 'item_image';
+	/**
+	 * Item description field name.
+	 *
+	 * @var string
+	 */
+	public const ITEM_DESC = 'item_description';
 
+	/**
+	 * Item call-to-action field name.
+	 *
+	 * @var string
+	 */
 	public const ITEM_CTA_FIELD = 'item_cta';
 
+	/**
+	 * Attach the group to the Magazine block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -33,14 +101,29 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'UCSC Magazine', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The masthead fields and the item repeater.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_title_line_1_field(),
@@ -50,6 +133,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * First masthead line.
+	 *
+	 * @return array
+	 */
 	protected function get_title_line_1_field(): array {
 		return [
 			'type'  => 'text',
@@ -59,6 +147,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Second masthead line.
+	 *
+	 * @return array
+	 */
 	protected function get_title_line_2_field(): array {
 		return [
 			'type'  => 'text',
@@ -68,6 +161,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Subtitle shown beneath the masthead.
+	 *
+	 * @return array
+	 */
 	protected function get_subtitle_field(): array {
 		return [
 			'type'  => 'text',
@@ -77,6 +175,13 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * The repeater of magazine items.
+	 *
+	 * Rows collapse to their title in the editor.
+	 *
+	 * @return array
+	 */
 	protected function get_items(): array {
 		return [
 			'key'          => $this->get_field_key( self::ITEMS, self::NAME ),
@@ -95,6 +200,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * An item's title.
+	 *
+	 * @return array
+	 */
 	protected function get_item_title(): array {
 		return [
 			'type'  => 'text',
@@ -104,6 +214,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * An item's byline.
+	 *
+	 * @return array
+	 */
 	protected function get_item_byline(): array {
 		return [
 			'type'  => 'text',
@@ -113,6 +228,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * An item's image. Returned as an attachment ID.
+	 *
+	 * @return array
+	 */
 	protected function get_image_field(): array {
 		return [
 			'label'         => esc_html__( 'Image', 'ucsc' ),
@@ -123,6 +243,11 @@ class Magazine_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * An item's description.
+	 *
+	 * @return array
+	 */
 	protected function get_item_desc(): array {
 		return [
 			'type'  => 'textarea',

--- a/src/Blocks/Media_Coverage_Block.php
+++ b/src/Blocks/Media_Coverage_Block.php
@@ -1,23 +1,71 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Media coverage block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Blocks\Contracts\CTA_Field;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
+/**
+ * Field group for the Media Coverage block.
+ *
+ * A query-loop block over the media_coverage post type rather than posts,
+ * with a heading and a call-to-action link.
+ */
 class Media_Coverage_Block extends Query_Loop implements CTA_Field {
 
 	use With_CTA_Field;
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_media_coverage_block';
 
-	public const CTA_FIELD   = 'media_coverage_cta';
+	/**
+	 * Call-to-action field name.
+	 *
+	 * @var string
+	 */
+	public const CTA_FIELD = 'media_coverage_cta';
+	/**
+	 * Heading field name.
+	 *
+	 * @var string
+	 */
 	public const TITLE_FIELD = 'media_coverage_title';
 
+	/**
+	 * Label for a single card in manual mode.
+	 *
+	 * @var string
+	 */
 	protected string $default_manual_card_label = 'Media Coverage';
-	protected array $allowed_post_types         = [ 'media_coverage' ];
-	protected int $max_manual_cards             = 6;
+	/**
+	 * Manual mode selects media coverage entries, not posts.
+	 *
+	 * @var string[]
+	 */
+	protected array $allowed_post_types = [ 'media_coverage' ];
+	/**
+	 * Maximum number of manual cards.
+	 *
+	 * @var int
+	 */
+	protected int $max_manual_cards = 6;
 
+	/**
+	 * Attach the group to the Media Coverage block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -30,14 +78,29 @@ class Media_Coverage_Block extends Query_Loop implements CTA_Field {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Media Coverage', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The heading, query selection fields and coverage link.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_block_title_field(),
@@ -46,6 +109,11 @@ class Media_Coverage_Block extends Query_Loop implements CTA_Field {
 		];
 	}
 
+	/**
+	 * Heading shown above the coverage list.
+	 *
+	 * @return array
+	 */
 	protected function get_block_title_field(): array {
 		return [
 			'type'  => 'text',

--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -152,7 +152,7 @@ class News_Block extends ACF_Group {
 	 * Field group title.
 	 *
 	 * Note: reads "Modal Block", which looks like a copy-paste leftover
-	 * rather than a description of this block.
+	 * rather than a description of this block. Tracked in #122.
 	 *
 	 * @return string
 	 */

--- a/src/Blocks/News_Block.php
+++ b/src/Blocks/News_Block.php
@@ -1,29 +1,127 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * News block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
+/**
+ * Field group for the News block.
+ *
+ * The only block registered on every site rather than news sites alone, and
+ * the only one whose posts come from a remote REST API instead of the local
+ * database. It therefore defines its own taxonomy fields rather than using the
+ * Taxonomies contract, because its choices are remote taxonomies.
+ */
 class News_Block extends ACF_Group {
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'news_query_block';
 
-	public const TITLE         = 'news_title';
-	public const DESCRIPTION   = 'news_desc';
-	public const LAYOUT        = 'layout';
-	public const LAYOUT_LEFT   = 'layout_left';
+	/**
+	 * Heading field name.
+	 *
+	 * @var string
+	 */
+	public const TITLE = 'news_title';
+	/**
+	 * Description field name.
+	 *
+	 * @var string
+	 */
+	public const DESCRIPTION = 'news_desc';
+	/**
+	 * Header alignment field name.
+	 *
+	 * @var string
+	 */
+	public const LAYOUT = 'layout';
+	/**
+	 * Header alignment value: left.
+	 *
+	 * @var string
+	 */
+	public const LAYOUT_LEFT = 'layout_left';
+	/**
+	 * Header alignment value: centred. The default.
+	 *
+	 * @var string
+	 */
 	public const LAYOUT_CENTRE = 'layout_centre';
 
+	/**
+	 * "More news" link field name.
+	 *
+	 * @var string
+	 */
 	public const MORE_NEWS_LINK = 'more_news_link';
 
+	/**
+	 * Remote taxonomy selector field name.
+	 *
+	 * @var string
+	 */
 	public const TAXONOMIES = 'taxonomies';
-	public const TAX_ITEMS  = 'taxonomy_items';
+	/**
+	 * Remote term selector field name.
+	 *
+	 * @var string
+	 */
+	public const TAX_ITEMS = 'taxonomy_items';
 
-	public const HIDE_EXCERPT  = 'hide_excerpt';
-	public const HIDE_IMAGE    = 'hide_image';
-	public const HIDE_DATE     = 'hide_date';
-	public const HIDE_AUTHOR   = 'hide_author';
-	public const HIDE_TAGS     = 'hide_tags';
+	/**
+	 * Toggle field name: hide the excerpt.
+	 *
+	 * @var string
+	 */
+	public const HIDE_EXCERPT = 'hide_excerpt';
+	/**
+	 * Toggle field name: hide the featured image.
+	 *
+	 * @var string
+	 */
+	public const HIDE_IMAGE = 'hide_image';
+	/**
+	 * Toggle field name: hide the published date.
+	 *
+	 * @var string
+	 */
+	public const HIDE_DATE = 'hide_date';
+	/**
+	 * Toggle field name: hide the author.
+	 *
+	 * @var string
+	 */
+	public const HIDE_AUTHOR = 'hide_author';
+	/**
+	 * Toggle field name: hide tags.
+	 *
+	 * @var string
+	 */
+	public const HIDE_TAGS = 'hide_tags';
+	/**
+	 * Toggle field name: hide the category.
+	 *
+	 * @var string
+	 */
 	public const HIDE_CATEGORY = 'hide_category';
 
+	/**
+	 * Remote taxonomies an editor may query.
+	 *
+	 * Acts as the allow-list for the taxonomy dropdown, and is the list the
+	 * unsanitised AJAX handler should be validating against; see #103.
+	 *
+	 * @var string[]
+	 */
 	public const ALLOWED_TAX = [
 		'academics',
 		'administration',
@@ -33,6 +131,11 @@ class News_Block extends ACF_Group {
 		'post_tag',
 	];
 
+	/**
+	 * Attach the group to the News block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -45,14 +148,32 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * Note: reads "Modal Block", which looks like a copy-paste leftover
+	 * rather than a description of this block.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Modal Block', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The block's fields: content, query and display toggles.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		$toggle_fields = [
 			self::HIDE_IMAGE    => esc_html__( 'Hide Featured Image', 'ucsc' ),
@@ -76,12 +197,17 @@ class News_Block extends ACF_Group {
 				$this->get_more_news_link_field(),
 				$this->get_taxonomies_list(),
 				$this->get_taxonomies_items(),
-				$this->get_posts_per_page_field(), // Add the dropdown field here
+				$this->get_posts_per_page_field(),
 			],
 			$fields
 		);
 	}
 
+	/**
+	 * Remote taxonomy selector. Choices are filled in by News_Blocks_Hooks.
+	 *
+	 * @return array
+	 */
 	private function get_taxonomies_list(): array {
 		return [
 			'key'           => $this->get_field_key( self::TAXONOMIES, self::NAME ),
@@ -95,6 +221,11 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Remote term selector. Multi-select, AJAX-backed.
+	 *
+	 * @return array
+	 */
 	private function get_taxonomies_items(): array {
 		return [
 			'key'           => $this->get_field_key( self::TAX_ITEMS, self::NAME ),
@@ -110,6 +241,14 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Build one display toggle.
+	 *
+	 * @param string $name  Field name.
+	 * @param string $label Editor-facing label.
+	 *
+	 * @return array
+	 */
 	private function get_toggle_field( string $name, string $label ): array {
 		return [
 			'key'           => $this->get_field_key( $name, self::NAME ),
@@ -121,6 +260,11 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Heading shown above the posts.
+	 *
+	 * @return array
+	 */
 	private function get_title_field(): array {
 		return [
 			'key'   => $this->get_field_key( self::TITLE, self::NAME ),
@@ -130,6 +274,11 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Header alignment, centred by default.
+	 *
+	 * @return array
+	 */
 	private function get_layout_field(): array {
 		return [
 			'key'           => $this->get_field_key( self::LAYOUT, self::NAME ),
@@ -145,6 +294,11 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Description shown beneath the heading.
+	 *
+	 * @return array
+	 */
 	private function get_desc_field(): array {
 		return [
 			'key'   => $this->get_field_key( self::DESCRIPTION, self::NAME ),
@@ -154,6 +308,11 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Optional link rendered after the posts.
+	 *
+	 * @return array
+	 */
 	private function get_more_news_link_field(): array {
 		return [
 			'key'   => $this->get_field_key( self::MORE_NEWS_LINK, self::NAME ),
@@ -163,6 +322,14 @@ class News_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * How many posts to render.
+	 *
+	 * Blocks inserted before this field existed have no saved value; see #106
+	 * for the resulting empty-block behaviour.
+	 *
+	 * @return array
+	 */
 	private function get_posts_per_page_field(): array {
 		return [
 			'key'           => $this->get_field_key( 'posts_per_page', self::NAME ),
@@ -174,7 +341,7 @@ class News_Block extends ACF_Group {
 				6 => '6 Posts',
 				9 => '9 Posts',
 			],
-			'default_value' => 3, // Default to 3 posts
+			'default_value' => 3,
 			'ui'            => 1,
 			'return_format' => 'value',
 			'instructions'  => esc_html__( 'Select the number of posts to display in the block.', 'ucsc' ),

--- a/src/Blocks/Photo_Of_The_Week_Block.php
+++ b/src/Blocks/Photo_Of_The_Week_Block.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
@@ -6,15 +13,41 @@ use UCSC\Blocks\Blocks\Contracts\CTA_Field;
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
+/**
+ * Field group for the Photo of the Week block.
+ *
+ * Selects a single published Photo of the Week entry to feature, with a
+ * heading and a link to the full archive.
+ */
 class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
 
 	use With_CTA_Field;
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_photo_of_the_week';
 
+	/**
+	 * Heading field name.
+	 *
+	 * @var string
+	 */
 	public const TITLE = 'title';
+	/**
+	 * Photo selector field name.
+	 *
+	 * @var string
+	 */
 	public const PHOTO = 'ucsc_photo_single';
 
+	/**
+	 * Attach the group to the Photo of the Week block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -27,14 +60,29 @@ class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'UCSC Photo of the Week Block', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The heading, archive link and photo selector.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_title_field(),
@@ -43,6 +91,11 @@ class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
 		];
 	}
 
+	/**
+	 * Heading shown above the photo.
+	 *
+	 * @return array
+	 */
 	protected function get_title_field(): array {
 		return [
 			'type'  => 'text',
@@ -52,6 +105,13 @@ class Photo_Of_The_Week_Block extends ACF_Group implements CTA_Field {
 		];
 	}
 
+	/**
+	 * The featured photo.
+	 *
+	 * Restricted to published Photo of the Week entries.
+	 *
+	 * @return array
+	 */
 	protected function get_photo_field(): array {
 		return [
 			'type'          => 'post_object',

--- a/src/Blocks/Post_Header_Block.php
+++ b/src/Blocks/Post_Header_Block.php
@@ -1,19 +1,57 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Post header block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Blocks\Traits\With_CTA_Field;
 
+/**
+ * Field group for the Post Header block.
+ *
+ * Chooses between the small and large featured-image treatments used at
+ * the top of a single post.
+ */
 class Post_Header_Block extends ACF_Group {
 
 	use With_CTA_Field;
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_post_header_block';
 
-	public const LAYOUT       = 'layout';
+	/**
+	 * Layout selector field name.
+	 *
+	 * @var string
+	 */
+	public const LAYOUT = 'layout';
+	/**
+	 * Layout value: small image. The default.
+	 *
+	 * @var string
+	 */
 	public const LAYOUT_SMALL = 'layout_small';
-	public const LAYOUT_BIG   = 'layout_big';
+	/**
+	 * Layout value: large image.
+	 *
+	 * @var string
+	 */
+	public const LAYOUT_BIG = 'layout_big';
 
+	/**
+	 * Attach the group to the Post Header block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -26,20 +64,40 @@ class Post_Header_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Post Header', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The layout selector.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_layout_field(),
 		];
 	}
 
+	/**
+	 * Featured image treatment, small by default.
+	 *
+	 * @return array
+	 */
 	protected function get_layout_field(): array {
 		return [
 			'type'          => 'radio',

--- a/src/Blocks/Press_Inquiries_Block.php
+++ b/src/Blocks/Press_Inquiries_Block.php
@@ -1,23 +1,86 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Press inquiries block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Integrations\ACF_Toolbars;
 
+/**
+ * Field group for the Press Inquiries block.
+ *
+ * Up to two press contacts, alongside optional downloadable assets and a
+ * short brief.
+ */
 class Press_Inquiries_Block extends ACF_Group {
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_press_inquiries';
 
-	public const POST_OVERLINE   = 'ucsc_post_overline';
+	/**
+	 * Overline field name. Currently unused by the field set.
+	 *
+	 * @var string
+	 */
+	public const POST_OVERLINE = 'ucsc_post_overline';
+	/**
+	 * Repeater field name holding the press contacts.
+	 *
+	 * @var string
+	 */
 	public const PRESS_INQUIRIES = 'ucsc_press_inquiries';
-	public const PRESS_NAME      = 'ucsc_press_name';
-	public const PRESS_EMAIL     = 'ucsc_press_email';
-	public const PRESS_PHONE     = 'ucsc_press_phone';
+	/**
+	 * Contact name field name. Also the collapsed-row label.
+	 *
+	 * @var string
+	 */
+	public const PRESS_NAME = 'ucsc_press_name';
+	/**
+	 * Contact email field name.
+	 *
+	 * @var string
+	 */
+	public const PRESS_EMAIL = 'ucsc_press_email';
+	/**
+	 * Contact phone field name.
+	 *
+	 * @var string
+	 */
+	public const PRESS_PHONE = 'ucsc_press_phone';
 
-	public const MEDIA_FILE  = 'ucsc_media_file';
+	/**
+	 * Downloadable paper field name.
+	 *
+	 * @var string
+	 */
+	public const MEDIA_FILE = 'ucsc_media_file';
+	/**
+	 * Downloadable image field name.
+	 *
+	 * @var string
+	 */
 	public const MEDIA_IMAGE = 'ucsc_media_image';
-	public const MEDIA_TEXT  = 'ucsc_media_text';
+	/**
+	 * Brief field name.
+	 *
+	 * @var string
+	 */
+	public const MEDIA_TEXT = 'ucsc_media_text';
 
+	/**
+	 * Attach the group to the Press Inquiries block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -30,14 +93,29 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Press Inquiries', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The contacts repeater, downloadable assets and brief.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_post_inquiries(),
@@ -47,6 +125,13 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * The repeater of press contacts, capped at two.
+	 *
+	 * Rows collapse to the contact name in the editor.
+	 *
+	 * @return array
+	 */
 	protected function get_post_inquiries(): array {
 		return [
 			'key'          => $this->get_field_key( self::PRESS_INQUIRIES, self::NAME ),
@@ -64,6 +149,11 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * A contact's name.
+	 *
+	 * @return array
+	 */
 	protected function get_name_field(): array {
 		return [
 			'type'  => 'text',
@@ -73,6 +163,11 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * A contact's email address. Stored as plain text.
+	 *
+	 * @return array
+	 */
 	protected function get_email_field(): array {
 		return [
 			'type'  => 'text',
@@ -82,6 +177,11 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * A contact's phone number. Stored as plain text.
+	 *
+	 * @return array
+	 */
 	protected function get_phone_field(): array {
 		return [
 			'type'  => 'text',
@@ -91,6 +191,11 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * An optional downloadable paper. Returned as a URL.
+	 *
+	 * @return array
+	 */
 	protected function get_media(): array {
 		return [
 			'label'         => esc_html__( 'Access paper', 'ucsc' ),
@@ -102,6 +207,11 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * An optional downloadable image. Returned as a URL.
+	 *
+	 * @return array
+	 */
 	protected function get_image(): array {
 		return [
 			'label'         => esc_html__( 'Image Download', 'ucsc' ),
@@ -113,6 +223,14 @@ class Press_Inquiries_Block extends ACF_Group {
 		];
 	}
 
+	/**
+	 * A short brief.
+	 *
+	 * Uses the cut-down toolbar so editors cannot introduce formatting the
+	 * block layout does not support.
+	 *
+	 * @return array
+	 */
 	protected function get_text_field(): array {
 		return [
 			'type'         => 'wysiwyg',

--- a/src/Blocks/Query_Loop.php
+++ b/src/Blocks/Query_Loop.php
@@ -181,7 +181,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 	 * The mode selector. Defaults to latest.
 	 *
 	 * Note: the method name is misspelled ("filed"); left as-is to avoid an
-	 * unrelated rename in a documentation change.
+	 * unrelated rename in a documentation change. Tracked in #123.
 	 *
 	 * @return array
 	 */

--- a/src/Blocks/Query_Loop.php
+++ b/src/Blocks/Query_Loop.php
@@ -1,60 +1,153 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Query-loop field group base class.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
 use UCSC\Blocks\Blocks\Contracts\Taxonomies;
 use UCSC\Blocks\Blocks\Traits\With_Taxonomies;
 
+/**
+ * Base for field groups that let an editor choose which posts to display.
+ *
+ * Offers three mutually exclusive modes, switched by the QUERY_TYPE button
+ * group and shown or hidden with ACF conditional logic:
+ *
+ *   latest     the most recent posts, no further configuration
+ *   automatic  every post in a chosen taxonomy term
+ *   manual     a hand-picked, ordered list of posts
+ *
+ * Subclasses override the protected properties to change the card label,
+ * limits and allowed post types. Query_Loop_Controller reads the saved values
+ * back out.
+ */
 abstract class Query_Loop extends ACF_Group implements Taxonomies {
 
 	use With_Taxonomies;
 
+	/**
+	 * Field name of the group wrapping the whole query configuration.
+	 *
+	 * @var string
+	 */
 	public const QUERY_LOOP = 'query_loop';
-	public const QUERY_TYPE = 'query_type';
-	public const LATEST     = 'latest';
-	public const AUTOMATIC  = 'automatic';
-	public const MANUAL     = 'manual';
-
-	public const AUTOMATIC_GROUP = 'automatic_group';
-	public const CATEGORIES      = 'categories';
-
-	public const MANUAL_CARDS = 'manual_cards';
-	public const MANUAL_CARD  = 'manual_card';
 
 	/**
-	 * Default label for single card on Manual Query
-	 * Add/Change in Block class in order to override
+	 * Field name of the mode selector.
+	 *
+	 * @var string
+	 */
+	public const QUERY_TYPE = 'query_type';
+
+	/**
+	 * Mode value: most recent posts.
+	 *
+	 * @var string
+	 */
+	public const LATEST = 'latest';
+
+	/**
+	 * Mode value: pull from a taxonomy term.
+	 *
+	 * @var string
+	 */
+	public const AUTOMATIC = 'automatic';
+
+	/**
+	 * Mode value: hand-picked posts.
+	 *
+	 * @var string
+	 */
+	public const MANUAL = 'manual';
+
+	/**
+	 * Field name of the group holding the automatic-mode fields.
+	 *
+	 * @var string
+	 */
+	public const AUTOMATIC_GROUP = 'automatic_group';
+
+	/**
+	 * Field name of the category selector.
+	 *
+	 * @var string
+	 */
+	public const CATEGORIES = 'categories';
+
+	/**
+	 * Field name of the manual-mode repeater.
+	 *
+	 * @var string
+	 */
+	public const MANUAL_CARDS = 'manual_cards';
+
+	/**
+	 * Field name of a single row within the manual repeater.
+	 *
+	 * @var string
+	 */
+	public const MANUAL_CARD = 'manual_card';
+
+	/**
+	 * Label for a single card in manual mode. Override per block.
+	 *
+	 * @var string
 	 */
 	protected string $default_manual_card_label = 'Card';
 
 	/**
-	 * Default max amount of cards applied to the manual query
-	 * Add/Change in Block class in order to override
+	 * Maximum number of manual cards. Override per block.
+	 *
+	 * @var int
 	 */
 	protected int $max_manual_cards = 4;
 
 	/**
-	 * Default min amount of cards applied to the manual query
-	 * Add/Change in Block class in order to override
+	 * Minimum number of manual cards. Override per block.
+	 *
+	 * @var int
 	 */
 	protected int $min_manual_cards = 0;
 
 	/**
-	 * Default instructions for cards
-	 * Add/Change in Block class in order to override
+	 * Editor instructions shown on the manual repeater. Override per block.
+	 *
+	 * @var string
 	 */
 	protected string $instructions = '';
 
 	/**
-	 * Default post_type for manual cards
-	 * Add/Change in Block class in order to override
+	 * The owning group name, used to compose every field key.
+	 *
+	 * Set by get_query_loop_group() rather than declared, because the field
+	 * definitions are built before the subclass name is otherwise available.
+	 *
+	 * @var string
 	 */
 	protected string $block_name = '';
 
+	/**
+	 * Post types selectable in manual mode. Override per block.
+	 *
+	 * @var string[]
+	 */
 	protected array $allowed_post_types = [
 		'post',
 	];
 
+	/**
+	 * Build the whole query-selection field group.
+	 *
+	 * @param string $name               The owning group name.
+	 * @param array  $allowed_post_types Post types offered in manual mode; falls back to the default.
+	 *
+	 * @return array
+	 */
 	public function get_query_loop_group( string $name, array $allowed_post_types = [] ): array {
 		$this->block_name = $name;
 
@@ -71,6 +164,11 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		];
 	}
 
+	/**
+	 * The three mode-specific field sets.
+	 *
+	 * @return array
+	 */
 	protected function get_sub_fields(): array {
 		return [
 			$this->get_query_type_filed(),
@@ -79,6 +177,14 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		];
 	}
 
+	/**
+	 * The mode selector. Defaults to latest.
+	 *
+	 * Note: the method name is misspelled ("filed"); left as-is to avoid an
+	 * unrelated rename in a documentation change.
+	 *
+	 * @return array
+	 */
 	protected function get_query_type_filed(): array {
 		return [
 			'key'           => $this->get_field_key( self::QUERY_TYPE, $this->block_name ),
@@ -95,6 +201,14 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		];
 	}
 
+	/**
+	 * Fields shown in automatic mode: taxonomy and term pickers.
+	 *
+	 * Note: the label is esc_html__( '', 'ucsc' ), which returns the PO file's
+	 * metadata header rather than an empty string. Tracked in #106.
+	 *
+	 * @return array
+	 */
 	protected function get_automatic_query(): array {
 		return [
 			'key'               => $this->get_field_key( self::AUTOMATIC_GROUP, $this->block_name ),
@@ -120,6 +234,14 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		];
 	}
 
+	/**
+	 * A category selector.
+	 *
+	 * Not currently wired into get_sub_fields(); kept for blocks that query
+	 * categories directly rather than through the taxonomy picker.
+	 *
+	 * @return array
+	 */
 	protected function get_categories_field(): array {
 		return [
 			'key'           => $this->get_field_key( self::CATEGORIES, self::AUTOMATIC_GROUP ),
@@ -134,6 +256,11 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		];
 	}
 
+	/**
+	 * The manual-mode repeater of hand-picked posts.
+	 *
+	 * @return array
+	 */
 	protected function get_manual_query(): array {
 		return [
 			'key'               => $this->get_field_key( self::MANUAL_CARDS, $this->block_name ),
@@ -159,6 +286,11 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		];
 	}
 
+	/**
+	 * A single post picker within the manual repeater.
+	 *
+	 * @return array
+	 */
 	protected function get_manual_card(): array {
 		return [
 			'key'           => $this->get_field_key( self::MANUAL_CARD, $this->block_name ),

--- a/src/Blocks/Related_Stories_Block.php
+++ b/src/Blocks/Related_Stories_Block.php
@@ -1,15 +1,47 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Related stories block field group.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks;
 
+/**
+ * Field group for the Related Stories block.
+ *
+ * A query-loop block with no additional fields, capped at three stories.
+ */
 class Related_Stories_Block extends Query_Loop {
 
+	/**
+	 * Field group name and key.
+	 *
+	 * @var string
+	 */
 	public const NAME = 'ucsc_related_stories_block';
 
+	/**
+	 * Maximum number of manual cards.
+	 *
+	 * @var int
+	 */
 	protected int $max_manual_cards = 3;
 
+	/**
+	 * Label for a single card in manual mode.
+	 *
+	 * @var string
+	 */
 	protected string $default_manual_card_label = 'Story';
 
+	/**
+	 * Attach the group to the Related Stories block.
+	 *
+	 * @return array
+	 */
 	protected function get_locations(): array {
 		return [
 			[
@@ -22,14 +54,29 @@ class Related_Stories_Block extends Query_Loop {
 		];
 	}
 
+	/**
+	 * Field group title.
+	 *
+	 * @return string
+	 */
 	protected function get_title(): string {
 		return esc_html__( 'Related Stories', 'ucsc' );
 	}
 
+	/**
+	 * Field group key.
+	 *
+	 * @return string
+	 */
 	protected function get_key(): string {
 		return self::NAME;
 	}
 
+	/**
+	 * The query selection fields.
+	 *
+	 * @return array
+	 */
 	protected function get_fields(): array {
 		return [
 			$this->get_query_loop_group( self::NAME ),

--- a/src/Blocks/Traits/With_CTA_Field.php
+++ b/src/Blocks/Traits/With_CTA_Field.php
@@ -1,9 +1,30 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Shared call-to-action field definition.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks\Traits;
 
+/**
+ * Supplies the call-to-action link field for the CTA_Field contract.
+ */
 trait With_CTA_Field {
 
+	/**
+	 * The call-to-action link field.
+	 *
+	 * ACF link fields return an array of title, url and target.
+	 *
+	 * @param string $group_name The owning group name, used to compose the field key.
+	 * @param string $label      Editor-facing label.
+	 * @param string $name       Field name; falls back to self::CTA when empty.
+	 *
+	 * @return array
+	 */
 	public function get_cta_field( string $group_name, string $label, string $name = '' ): array {
 		return [
 			'label' => $label,

--- a/src/Blocks/Traits/With_Taxonomies.php
+++ b/src/Blocks/Traits/With_Taxonomies.php
@@ -1,9 +1,30 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Shared taxonomy field definitions.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Blocks\Traits;
 
+/**
+ * Supplies the taxonomy and term picker fields for the Taxonomies contract.
+ *
+ * Both fields ship with empty choices: they are populated at edit time by the
+ * ACF load filters in src/Hooks/, which is why their names must match the
+ * contract's constants exactly.
+ */
 trait With_Taxonomies {
 
+	/**
+	 * The taxonomy selector field.
+	 *
+	 * @param string $name The owning group name, used to compose the field key.
+	 *
+	 * @return array
+	 */
 	public function get_taxonomies_list( string $name ): array {
 		return [
 			'key'           => $this->get_field_key( self::TAXONOMIES, $name ),
@@ -17,6 +38,16 @@ trait With_Taxonomies {
 		];
 	}
 
+	/**
+	 * The term selector field.
+	 *
+	 * AJAX-backed, so terms are searched remotely rather than rendered as a
+	 * full list up front.
+	 *
+	 * @param string $name The owning group name, used to compose the field key.
+	 *
+	 * @return array
+	 */
 	public function get_taxonomies_items( string $name ): array {
 		return [
 			'key'           => $this->get_field_key( self::TAX_ITEMS, $name ),


### PR DESCRIPTION
## What does this do/fix?

Step 3 of #116, **slice 2 of 4** — `src/Blocks/`.

**phpcs: 446 errors → 329.** 14 files.

Covers the `ACF_Group` base, the `Query_Loop` base, both contracts, both field traits, and all eight concrete block field groups.

### Remaining slices

| slice | scope | count |
|---|---|---|
| ~~1~~ | ~~bootstrap + infrastructure~~ | ~~103~~ ✅ #120 |
| ~~2~~ | ~~`src/Blocks/`~~ | ~~117~~ ✅ this PR |
| 3 | `src/Components/` | 125 |
| 4 | `src/Template/` + `src/views/` | 51 |

## Where the detail went

The eight concrete blocks are largely declarative — arrays of ACF field definitions — so documenting each field individually would add volume without adding understanding. The explanatory weight sits in the base classes instead:

- **`ACF_Group`** — the three-part block structure (field group / controller / view), and why field *names* live as constants shared between the group and its controller rather than being written twice.
- **`Query_Loop`** — the three editor-selectable query modes (`latest`, `automatic`, `manual`), and how ACF conditional logic switches the field sets.
- **`Contracts/`** — why the field-name constants must match what the ACF load filters in `src/Hooks/` target by name; renaming one silently empties the editor dropdowns.

The concrete blocks then get a class-level note on what makes each one different — Media Coverage queries a different post type, News is the only block reading a remote API, Press Inquiries caps its repeater at two.

## Docblocks name open bugs rather than blessing them

| location | note | issue |
|---|---|---|
| `Query_Loop::get_automatic_query()` | label is `esc_html__( '', 'ucsc' )`, which returns the PO metadata header | #106 |
| `News_Block::get_posts_per_page_field()` | blocks predating the field have no saved value | #106 |
| `News_Block::ALLOWED_TAX` | this is the list the unsanitised AJAX handler should validate against | #103 |

## Two things noticed, deliberately not fixed

Both are recorded in the docblocks rather than changed, since this is a documentation PR:

- **`News_Block::get_title()` returns `'Modal Block'`.** That is the field group title an editor sees in the sidebar. It looks like a copy-paste leftover — worth confirming and renaming, but that is a user-visible string change.
- **`Query_Loop::get_query_type_filed()`** is misspelled. Renaming it is safe (it is `protected` and called once), but it belongs in a change that can be reviewed as a rename.

Say the word and I will open an issue for either.

Also removes two redundant trailing comments in `News_Block` (`// Add the dropdown field here`, `// Default to 3 posts`) that restated the line they sat on and were flagged for punctuation.

## Tests

```bash
composer lint    # 329 errors, down from 446
npm run build    # green
```

Verified locally:

- [x] All 14 changed files pass `php -l`
- [x] Zero documentation violations remain in `src/Blocks/`
- [x] **Documentation-only**: token streams compared with comments stripped and open-tag whitespace normalised — executable code identical across all 14 files
- [x] `npm run build` green

Reviewer checks — prose, so it wants reading:

- [ ] `ACF_Group` and `Query_Loop` class docs match your mental model of how blocks are assembled
- [ ] The three query modes are described accurately
- [ ] Per-block class docs correctly state what distinguishes each block
- [ ] Nothing reads as confidently wrong
