### PR TITLE
docs: add docblocks to block controllers (slice 3/4)

### DIFF
--- a/src/Components/Abstract_Controller.php
+++ b/src/Components/Abstract_Controller.php
@@ -1,9 +1,35 @@
 <?php
+/**
+ * Block controller base class.
+ *
+ * @package ucsc
+ */
 
 namespace UCSC\Blocks\Components;
 
+/**
+ * Shared behaviour for block controllers.
+ *
+ * A controller sits between an ACF field group and its view: it reads the
+ * saved field values into typed properties, does whatever querying or shaping
+ * the view needs, and exposes the result through accessors. Views should
+ * contain no query logic of their own.
+ *
+ * Despite the name this class is not abstract and is instantiated directly by
+ * some views.
+ */
 class Abstract_Controller {
 
+	/**
+	 * Build the block's outer wrapper attributes.
+	 *
+	 * Delegates to get_block_wrapper_attributes() so that alignment, custom
+	 * classes and other editor-set supports survive into the rendered markup.
+	 *
+	 * @param array $classes Extra classes to add to the wrapper.
+	 *
+	 * @return string The escaped attribute string.
+	 */
 	public function get_attributes( $classes = [] ): string {
 
 		return wp_kses_data(

--- a/src/Components/Featured_News_Block_Controller.php
+++ b/src/Components/Featured_News_Block_Controller.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Featured news block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
@@ -8,19 +15,46 @@ use UCSC\Blocks\Blocks\Query_Loop;
 use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
+/**
+ * Prepares posts for the Featured Stories block.
+ *
+ * The first card is rendered large and is the only one given an excerpt;
+ * the rest are compact.
+ */
 class Featured_News_Block_Controller extends Query_Loop_Controller {
 
 	use With_Image_Size;
 	use With_Primary_Term;
 
+	/**
+	 * How many posts to display.
+	 *
+	 * @var int
+	 */
 	protected int $number_of_posts_display = 4;
 
+	/**
+	 * Read the query configuration and the all-news link.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		parent::__construct( $block );
 
 		$this->cta = (array) get_field( Featured_News_Block::CTA_FIELD ) ?: [];
 	}
 
+	/**
+	 * Shape each post into a card.
+	 *
+	 * Skips invalid IDs, which manual mode can leave behind when a selected
+	 * post is later deleted.
+	 *
+	 * @param array $posts         Post IDs to prepare.
+	 * @param bool  $is_auto_query Whether the IDs came from the automatic query.
+	 *
+	 * @return array
+	 */
 	protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array {
 		$items = [];
 
@@ -47,7 +81,7 @@ class Featured_News_Block_Controller extends Query_Loop_Controller {
 				'category' => $category,
 			];
 
-			// Large card
+			// Large card.
 			if ( $key === 0 ) {
 				$args['excerpt'] = get_the_excerpt( $post_id );
 			}

--- a/src/Components/Magazine_Block_Controller.php
+++ b/src/Components/Magazine_Block_Controller.php
@@ -1,20 +1,49 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Magazine block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
 use UCSC\Blocks\Blocks\Magazine_Block;
 use UCSC\Blocks\Components\Traits\With_Image_Size;
 
+/**
+ * Prepares the Magazine block's items for rendering.
+ *
+ * Reads a repeater rather than running a query: every item is authored by
+ * hand in the editor. The tab keys it generates tie each tab to its panel
+ * for the block's front-end script.
+ */
 class Magazine_Block_Controller {
 
 	use With_Image_Size;
 
+	/**
+	 * The block instance passed to the render callback.
+	 *
+	 * @var array
+	 */
 	protected array $block;
 
+	/**
+	 * Store the block instance.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		$this->block = (array) $block;
 	}
 
+	/**
+	 * The block's wrapper attributes.
+	 *
+	 * @return string
+	 */
 	public function get_attributes(): string {
 		return wp_kses_data(
 			get_block_wrapper_attributes(
@@ -34,24 +63,44 @@ class Magazine_Block_Controller {
 		);
 	}
 
+	/**
+	 * First masthead line, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_title_line_1(): string {
 		$overline = (string) get_field( Magazine_Block::TITLE_LINE_1 );
 
 		return strlen( $overline ) < 1 ? '' : $overline;
 	}
 
+	/**
+	 * Second masthead line, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_title_line_2(): string {
 		$title = (string) get_field( Magazine_Block::TITLE_LINE_2 );
 
 		return strlen( $title ) < 1 ? '' : $title;
 	}
 
+	/**
+	 * Subtitle, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_subtitle(): string {
 		$subtitle = (string) get_field( Magazine_Block::SUBTITLE );
 
 		return strlen( $subtitle ) < 1 ? '' : $subtitle;
 	}
 
+	/**
+	 * The magazine items, with empty repeater rows discarded.
+	 *
+	 * @return array
+	 */
 	public function get_magazines(): array {
 		$magazines = (array) get_field( Magazine_Block::ITEMS );
 
@@ -67,6 +116,19 @@ class Magazine_Block_Controller {
 		);
 	}
 
+	/**
+	 * Build the id used to tie a tab to its panel.
+	 *
+	 * Derived from the item title and its position, so the pairing survives
+	 * reordering. The optional element suffix distinguishes the tab, its
+	 * label and its panel.
+	 *
+	 * @param array  $magazine The item.
+	 * @param int    $index    Zero-based position.
+	 * @param string $element  Optional suffix, e.g. 'label' or 'panel'.
+	 *
+	 * @return string
+	 */
 	public function make_tab_key( array $magazine, int $index, string $element = '' ): string {
 		return sprintf(
 			'%s-%s%s',
@@ -76,6 +138,15 @@ class Magazine_Block_Controller {
 		);
 	}
 
+	/**
+	 * An item's call to action, or an empty array.
+	 *
+	 * Returns nothing unless both a title and a URL were entered.
+	 *
+	 * @param array $magazine The item.
+	 *
+	 * @return array
+	 */
 	public function get_cta( array $magazine ): array {
 		if ( empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ] ) || empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['title'] ) || empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['url'] ) ) {
 			return [];
@@ -88,6 +159,13 @@ class Magazine_Block_Controller {
 		];
 	}
 
+	/**
+	 * An item's image as responsive markup, or an empty string.
+	 *
+	 * @param array $magazine The item.
+	 *
+	 * @return string
+	 */
 	public function get_image( array $magazine ): string {
 		if ( empty( $magazine[ Magazine_Block::ITEM_IMAGE ] ) ) {
 			return '';
@@ -116,6 +194,13 @@ class Magazine_Block_Controller {
 		);
 	}
 
+	/**
+	 * An item's description, or an empty string.
+	 *
+	 * @param array $magazine The item.
+	 *
+	 * @return string
+	 */
 	public function get_description( array $magazine ): string {
 		$description = (string) $magazine[ Magazine_Block::ITEM_DESC ];
 

--- a/src/Components/Media_Coverage_Controller.php
+++ b/src/Components/Media_Coverage_Controller.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Media coverage block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
@@ -6,20 +13,47 @@ use UCSC\Blocks\Blocks\Media_Coverage_Block;
 use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
+/**
+ * Prepares entries for the Media Coverage block.
+ *
+ * Queries the media_coverage post type rather than posts. Each entry links
+ * out to coverage on another site, so the source name and URL come from
+ * per-post ACF fields rather than from the permalink.
+ */
 class Media_Coverage_Controller extends Query_Loop_Controller {
 
 	use With_Image_Size;
 	use With_Primary_Term;
 
+	/**
+	 * How many entries to display.
+	 *
+	 * @var int
+	 */
 	protected int $number_of_posts_display = 6;
-	protected array $post_types            = [ 'media_coverage' ];
+	/**
+	 * Queries media coverage entries rather than posts.
+	 *
+	 * @var string[]
+	 */
+	protected array $post_types = [ 'media_coverage' ];
 
+	/**
+	 * Read the query configuration and the all-coverage link.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		parent::__construct( $block );
 
 		$this->cta = (array) get_field( Media_Coverage_Block::CTA_FIELD ) ?: [];
 	}
 
+	/**
+	 * The block's wrapper attributes.
+	 *
+	 * @return string
+	 */
 	public function get_attributes(): string {
 		return wp_kses_data(
 			get_block_wrapper_attributes(
@@ -39,18 +73,40 @@ class Media_Coverage_Controller extends Query_Loop_Controller {
 		);
 	}
 
+	/**
+	 * The block heading, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_title(): string {
 		$title = (string) get_field( Media_Coverage_Block::TITLE_FIELD );
 
 		return strlen( $title ) < 1 ? '' : $title;
 	}
 
+	/**
+	 * Whether a URL points at this site.
+	 *
+	 * Lets the view mark outbound coverage links differently.
+	 *
+	 * @param string $url URL to test.
+	 *
+	 * @return bool
+	 */
 	public function is_internal_url( string $url ): bool {
 		$current_site = get_bloginfo( 'url' );
 
 		return stripos( $url, $current_site ) !== false;
 	}
 
+	/**
+	 * Shape each coverage entry into a card.
+	 *
+	 * @param array $posts         Post IDs to prepare.
+	 * @param bool  $is_auto_query Whether the IDs came from the automatic query.
+	 *
+	 * @return array
+	 */
 	protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array {
 		$items = [];
 

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -1,32 +1,156 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * News block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
 use UCSC\Blocks\Blocks\News_Block;
 use UCSC\Blocks\Request\News_Request;
 
+/**
+ * Prepares the News block's posts for rendering.
+ *
+ * The only controller that sources its content remotely: posts, media,
+ * authors and terms are all fetched from the news site over REST rather than
+ * queried locally. Everything is cached in transients for 20 minutes.
+ *
+ * Note: a cold render issues one request for the posts and then a further
+ * request per featured image, per author and per taxonomy, which can mean
+ * well over a dozen sequential blocking calls. Batching these via _embed is
+ * tracked in #107.
+ */
 class News_Block_Controller {
 
-	public const POSTS              = 'news_posts';
-	public const PER_PAGE           = 9;
-	private const CACHE_EXPIRY      = MINUTE_IN_SECONDS * 20;
+	/**
+	 * Transient key prefix for cached responses.
+	 *
+	 * @var string
+	 */
+	public const POSTS = 'news_posts';
+	/**
+	 * Posts requested from the API.
+	 *
+	 * Fixed at the maximum the block offers; the editor's chosen count is
+	 * applied by slicing the result rather than by narrowing the request.
+	 *
+	 * @var int
+	 */
+	public const PER_PAGE = 9;
+	/**
+	 * How long fetched data stays cached.
+	 *
+	 * @var int
+	 */
+	private const CACHE_EXPIRY = MINUTE_IN_SECONDS * 20;
+	/**
+	 * Author used when a post has no coauthors.
+	 *
+	 * A remote author ID on the news site, hardcoded here.
+	 *
+	 * @var int
+	 */
 	private const DEFAULT_AUTHOR_ID = 11;
 
+	/**
+	 * The block instance passed to the render callback.
+	 *
+	 * @var array
+	 */
 	protected array $block;
+	/**
+	 * REST base of the taxonomy being queried.
+	 *
+	 * @var string
+	 */
 	private string $taxonomy;
+	/**
+	 * Remote term IDs to filter posts by.
+	 *
+	 * @var int[]
+	 */
 	private array $taxonomy_ids;
+	/**
+	 * Whether to omit the excerpt.
+	 *
+	 * @var bool
+	 */
 	private bool $hide_excerpt;
+	/**
+	 * Whether to omit the author.
+	 *
+	 * @var bool
+	 */
 	private bool $hide_author;
+	/**
+	 * Whether to omit the featured image.
+	 *
+	 * @var bool
+	 */
 	private bool $hide_image;
+	/**
+	 * Whether to omit the published date.
+	 *
+	 * @var bool
+	 */
 	private bool $hide_date;
+	/**
+	 * Whether to omit tags.
+	 *
+	 * @var bool
+	 */
 	private bool $hide_tags;
+	/**
+	 * Whether to omit the category.
+	 *
+	 * @var bool
+	 */
 	private bool $hide_category;
+	/**
+	 * Heading shown above the posts.
+	 *
+	 * @var string
+	 */
 	private string $title;
+	/**
+	 * Description shown beneath the heading.
+	 *
+	 * @var string
+	 */
 	private string $description;
+	/**
+	 * Header alignment.
+	 *
+	 * @var string
+	 */
 	private string $layout;
+	/**
+	 * The optional "more news" link.
+	 *
+	 * @var array|string
+	 */
 	private array|string $more_news_link;
+	/**
+	 * How many posts to render.
+	 *
+	 * Blocks saved before this field existed resolve to 0, which renders an
+	 * empty block; tracked in #106.
+	 *
+	 * @var int
+	 */
 	private int $posts_per_page;
 
+	/**
+	 * Read every saved field value into typed properties.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 *
+	 * @return void
+	 */
 	public function __construct( $block ) {
 		$this->block          = (array) $block;
 		$this->title          = get_field( News_Block::TITLE ) ?? '';
@@ -44,18 +168,40 @@ class News_Block_Controller {
 		$this->posts_per_page = (int) get_field( 'posts_per_page' ) ?? self::PER_PAGE;
 	}
 
+	/**
+	 * The block heading.
+	 *
+	 * @return string
+	 */
 	public function get_title(): string {
 		return $this->title;
 	}
 
+	/**
+	 * The block description.
+	 *
+	 * @return string
+	 */
 	public function get_description(): string {
 		return $this->description;
 	}
 
+	/**
+	 * Header alignment modifier class, empty when centred.
+	 *
+	 * @return string
+	 */
 	public function get_alignment(): string {
 		return $this->layout !== News_Block::LAYOUT_CENTRE ? ' align-header-left' : '';
 	}
 
+	/**
+	 * The "more news" link, or an empty array when unset.
+	 *
+	 * Falls back to a default title when a URL was given without one.
+	 *
+	 * @return array
+	 */
 	public function get_more_news_link(): array {
 		$link = [];
 
@@ -68,6 +214,13 @@ class News_Block_Controller {
 		return $link;
 	}
 
+	/**
+	 * Build a srcset from the sizes in a remote media payload.
+	 *
+	 * @param array $sizes Size descriptors from the REST media response.
+	 *
+	 * @return string
+	 */
 	public function build_srcset( array $sizes = [] ): string {
 		if ( empty( $sizes ) ) {
 			return '';
@@ -81,6 +234,16 @@ class News_Block_Controller {
 		return implode( ', ', $urls );
 	}
 
+	/**
+	 * Fetch and shape the posts for rendering.
+	 *
+	 * Returns an empty array unless both a taxonomy and at least one term are
+	 * selected, so an unconfigured block renders nothing rather than an
+	 * arbitrary post list. Hidden fields are omitted here rather than in the
+	 * view, so the view does no conditional work.
+	 *
+	 * @return array
+	 */
 	public function get_items(): array {
 		if ( empty( $this->taxonomy_ids ) || empty( $this->taxonomy ) ) {
 			return [];
@@ -89,11 +252,10 @@ class News_Block_Controller {
 		$response = get_transient( $this->get_cache_key() );
 
 		if ( empty( $response ) ) {
-			// Fetch data using the constant PER_PAGE for the API request
 			$response = ( new News_Request() )->request(
 				News_Request::POSTS_ENDPOINT,
 				[
-					'per_page'      => self::PER_PAGE, // Use the constant here
+					'per_page'      => self::PER_PAGE,
 					$this->taxonomy => implode( ',', $this->taxonomy_ids ),
 				]
 			);
@@ -124,6 +286,17 @@ class News_Block_Controller {
 		return array_slice( $items, 0, $this->posts_per_page );
 	}
 
+	/**
+	 * Compose a transient key.
+	 *
+	 * Note: every key embeds the selected term IDs, so the same attachment or
+	 * author is cached separately for each block configuration that references
+	 * it. Keying per-object caches by object ID alone is tracked in #107.
+	 *
+	 * @param string $prefix Optional prefix identifying what is cached.
+	 *
+	 * @return string
+	 */
 	protected function get_cache_key( string $prefix = '' ): string {
 		if ( ! empty( $prefix ) ) {
 			return sprintf( '%s_%s_%s', $prefix, self::POSTS, implode( '_', $this->taxonomy_ids ) );
@@ -132,6 +305,13 @@ class News_Block_Controller {
 		return sprintf( '%s_%s', self::POSTS, implode( '_', $this->taxonomy_ids ) );
 	}
 
+	/**
+	 * Fetch a post's featured image.
+	 *
+	 * @param array $item A post from the REST response.
+	 *
+	 * @return array
+	 */
 	protected function get_item_attachment( array $item ): array {
 		if ( ! isset( $item['featured_media'] ) || $item['featured_media'] <= 0 ) {
 			return [];
@@ -159,6 +339,16 @@ class News_Block_Controller {
 		];
 	}
 
+	/**
+	 * Resolve a post's author names.
+	 *
+	 * Uses Co-Authors Plus data when the post has it, and falls back to a
+	 * single default author otherwise.
+	 *
+	 * @param array $item A post from the REST response.
+	 *
+	 * @return array
+	 */
 	protected function get_authors( array $item ): array {
 		if ( ! empty( $item['coauthors'] ) ) {
 			$authors = [];
@@ -194,6 +384,14 @@ class News_Block_Controller {
 		return [ $user['title']['rendered'] ?? $user['name'] ];
 	}
 
+	/**
+	 * Fetch up to three term names for a post.
+	 *
+	 * @param array $item   A post from the REST response.
+	 * @param bool  $is_tag Read tags rather than the selected taxonomy.
+	 *
+	 * @return array
+	 */
 	protected function get_taxonomies( array $item, bool $is_tag = false ) {
 		$categories = [];
 

--- a/src/Components/Photo_Of_The_Week_Archive_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Archive_Controller.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week archive controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
@@ -6,10 +13,24 @@ use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Object_Meta\Photo_Of_The_Week_Meta;
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 
+/**
+ * Supplies the paginated query and markup for the Photo of the Week archive.
+ *
+ * Used by the archive template rather than by a block.
+ */
 class Photo_Of_The_Week_Archive_Controller {
 
 	use With_Image_Size;
 
+	/**
+	 * Query one page of published photos.
+	 *
+	 * Honours the site's posts-per-page setting.
+	 *
+	 * @param mixed $paged The page number being viewed.
+	 *
+	 * @return \WP_Query
+	 */
 	public function get_query( $paged ): \WP_Query {
 		return new \WP_Query(
 			[
@@ -23,6 +44,11 @@ class Photo_Of_The_Week_Archive_Controller {
 		);
 	}
 
+	/**
+	 * The current photo's attachment data, or an empty array.
+	 *
+	 * @return array
+	 */
 	public function get_image(): array {
 		$image = get_field( Photo_Of_The_Week_Meta::IMAGE, get_the_ID() );
 
@@ -33,6 +59,11 @@ class Photo_Of_The_Week_Archive_Controller {
 		return $image;
 	}
 
+	/**
+	 * The current photo as responsive markup, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function render_image(): string {
 		$image = $this->get_image();
 
@@ -58,6 +89,14 @@ class Photo_Of_The_Week_Archive_Controller {
 		);
 	}
 
+	/**
+	 * Pagination links for the archive.
+	 *
+	 * @param \WP_Query $query The archive query.
+	 * @param int       $paged The page number being viewed.
+	 *
+	 * @return array|string|null
+	 */
 	public function get_pagination( \WP_Query $query, int $paged ) {
 		return paginate_links(
 			[

--- a/src/Components/Photo_Of_The_Week_Block_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Block_Controller.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
@@ -7,19 +14,45 @@ use UCSC\Blocks\Components\Traits\With_CTA;
 use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Object_Meta\Photo_Of_The_Week_Meta;
 
+/**
+ * Prepares the single featured photo for the Photo of the Week block.
+ *
+ * The photograph and its credit live on the selected Photo of the Week post
+ * as ACF meta, so both are read from that post rather than from the block.
+ */
 class Photo_Of_The_Week_Block_Controller {
 
 	use With_Image_Size;
 	use With_CTA;
 
+	/**
+	 * The block instance passed to the render callback.
+	 *
+	 * @var array
+	 */
 	protected array $block;
+	/**
+	 * The link to the full photo archive.
+	 *
+	 * @var array
+	 */
 	protected array $cta;
 
+	/**
+	 * Store the block instance and read the archive link.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		$this->block = (array) $block;
 		$this->cta   = (array) get_field( Photo_Of_The_Week_Block::CTA );
 	}
 
+	/**
+	 * The block's wrapper attributes.
+	 *
+	 * @return string
+	 */
 	public function get_attributes(): string {
 		return wp_kses_data(
 			get_block_wrapper_attributes(
@@ -40,12 +73,24 @@ class Photo_Of_The_Week_Block_Controller {
 		);
 	}
 
+	/**
+	 * The block heading, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_title(): string {
 		$title = (string) get_field( Photo_Of_The_Week_Block::TITLE );
 
 		return strlen( $title ) > 0 ? $title : '';
 	}
 
+	/**
+	 * The featured photo, or null when none is selected.
+	 *
+	 * Bundles the rendered markup, a download URL, the title and the credit.
+	 *
+	 * @return array|null
+	 */
 	public function get_photo(): ?array {
 		$photo = (string) get_field( Photo_Of_The_Week_Block::PHOTO );
 
@@ -73,10 +118,24 @@ class Photo_Of_The_Week_Block_Controller {
 		];
 	}
 
+	/**
+	 * The photographer credit for a photo.
+	 *
+	 * @param mixed $photo_id The Photo of the Week post ID.
+	 *
+	 * @return string
+	 */
 	public function get_photo_author( $photo_id ): string {
 		return (string) get_field( Photo_Of_The_Week_Meta::PHOTOGRAPHER, $photo_id );
 	}
 
+	/**
+	 * The photograph's attachment data, or an empty array.
+	 *
+	 * @param mixed $photo_id The Photo of the Week post ID.
+	 *
+	 * @return array
+	 */
 	public function get_photo_image( $photo_id ): array {
 		$image = get_field( Photo_Of_The_Week_Meta::IMAGE, $photo_id );
 

--- a/src/Components/Post_Header_Block_Controller.php
+++ b/src/Components/Post_Header_Block_Controller.php
@@ -1,20 +1,48 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Post header block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
 use UCSC\Blocks\Blocks\Post_Header_Block;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
+/**
+ * Prepares the post header's layout, category and featured image.
+ *
+ * The image caption and credit are read from the attachment's excerpt and
+ * content fields, which is where WordPress stores them.
+ */
 class Post_Header_Block_Controller {
 
 	use With_Primary_Term;
 
+	/**
+	 * The block instance passed to the render callback.
+	 *
+	 * @var array
+	 */
 	protected array $block;
 
+	/**
+	 * Store the block instance.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		$this->block = (array) $block;
 	}
 
+	/**
+	 * The block's wrapper attributes, varying with the chosen layout.
+	 *
+	 * @return string
+	 */
 	public function get_attributes(): string {
 		$classes = [
 			'ucsc-post-header-block',
@@ -34,10 +62,22 @@ class Post_Header_Block_Controller {
 		);
 	}
 
+	/**
+	 * Whether the small-image layout is selected.
+	 *
+	 * The small-image treatment lays the header out horizontally.
+	 *
+	 * @return bool
+	 */
 	public function is_horizontal_layout(): bool {
 		return $this->get_layout() === Post_Header_Block::LAYOUT_SMALL;
 	}
 
+	/**
+	 * The post's primary category name, or null.
+	 *
+	 * @return string|null
+	 */
 	public function get_primary_category(): ?string {
 		$category = $this->get_primary_term( get_the_ID() );
 
@@ -48,6 +88,11 @@ class Post_Header_Block_Controller {
 		return (string) $category->name;
 	}
 
+	/**
+	 * The featured image with its caption and credit, or an empty array.
+	 *
+	 * @return array
+	 */
 	public function get_image(): array {
 		$thumbnail_id = get_post_thumbnail_id( get_the_ID() );
 		if ( empty( $thumbnail_id ) ) {
@@ -63,6 +108,11 @@ class Post_Header_Block_Controller {
 		];
 	}
 
+	/**
+	 * The chosen layout, defaulting to the small image.
+	 *
+	 * @return mixed
+	 */
 	protected function get_layout() {
 		return get_field( Post_Header_Block::LAYOUT ) ?? Post_Header_Block::LAYOUT_SMALL;
 	}

--- a/src/Components/Press_Inquiries_Controller.php
+++ b/src/Components/Press_Inquiries_Controller.php
@@ -1,17 +1,44 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Press inquiries block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
 use UCSC\Blocks\Blocks\Press_Inquiries_Block;
 
+/**
+ * Prepares the Press Inquiries block's contacts and assets.
+ *
+ * Entirely authored content; no querying.
+ */
 class Press_Inquiries_Controller {
 
+	/**
+	 * The block instance passed to the render callback.
+	 *
+	 * @var array
+	 */
 	protected array $block;
 
+	/**
+	 * Store the block instance.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		$this->block = (array) $block;
 	}
 
+	/**
+	 * The block's wrapper attributes.
+	 *
+	 * @return string
+	 */
 	public function get_attributes(): string {
 		return wp_kses_data(
 			get_block_wrapper_attributes(
@@ -30,6 +57,11 @@ class Press_Inquiries_Controller {
 		);
 	}
 
+	/**
+	 * The press contacts, or an empty array.
+	 *
+	 * @return array
+	 */
 	public function get_press_contacts(): array {
 		$contacts = get_field( Press_Inquiries_Block::PRESS_INQUIRIES );
 
@@ -40,18 +72,41 @@ class Press_Inquiries_Controller {
 		return $contacts;
 	}
 
+	/**
+	 * A unique id for the block's collapsible panel.
+	 *
+	 * Derived from the block instance id so several blocks on one page do not
+	 * collide.
+	 *
+	 * @return string
+	 */
 	public function get_panel_id(): string {
 		return esc_attr( 'press-inquiries-block-' . $this->block['id'] );
 	}
 
+	/**
+	 * The brief.
+	 *
+	 * @return string
+	 */
 	public function get_media_text(): string {
 		return (string) get_field( Press_Inquiries_Block::MEDIA_TEXT );
 	}
 
+	/**
+	 * URL of the downloadable paper, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_media_file(): string {
 		return (string) get_field( Press_Inquiries_Block::MEDIA_FILE );
 	}
 
+	/**
+	 * URL of the downloadable image, or an empty string.
+	 *
+	 * @return string
+	 */
 	public function get_media_image(): string {
 		return (string) get_field( Press_Inquiries_Block::MEDIA_IMAGE );
 	}

--- a/src/Components/Query_Loop_Controller.php
+++ b/src/Components/Query_Loop_Controller.php
@@ -1,30 +1,99 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Query-loop controller base class.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
 use UCSC\Blocks\Blocks\Query_Loop;
 use UCSC\Blocks\Components\Traits\With_CTA;
 
+/**
+ * Resolves a query-loop block's editor selection into post IDs.
+ *
+ * Mirrors Query_Loop on the field side: whichever of the three modes the
+ * editor picked, this class produces a list of post IDs and hands it to the
+ * subclass, which shapes each post into whatever its view needs.
+ *
+ * Subclasses override the protected properties to change how many posts are
+ * shown and which post types are queried.
+ */
 abstract class Query_Loop_Controller {
 
 	use With_CTA;
 
+	/**
+	 * The block instance passed to the render callback.
+	 *
+	 * @var array
+	 */
 	protected array $block;
+	/**
+	 * The call-to-action link, when the block has one.
+	 *
+	 * @var array
+	 */
 	protected array $cta;
+	/**
+	 * The saved query configuration group.
+	 *
+	 * @var array
+	 */
 	protected array $query_loop;
+	/**
+	 * Whether automatic mode omits the post being viewed.
+	 *
+	 * @var bool
+	 */
 	protected bool $exclude_current_post_from_query = true;
 
+	/**
+	 * How many posts to display. Override per block.
+	 *
+	 * @var int
+	 */
 	protected int $number_of_posts_display = 4;
-	protected array $post_types            = [ 'post' ];
+	/**
+	 * Post types to query. Override per block.
+	 *
+	 * @var string[]
+	 */
+	protected array $post_types = [ 'post' ];
 
+	/**
+	 * Shape resolved post IDs into the structure the view renders.
+	 *
+	 * Implemented per block.
+	 *
+	 * @param array $posts         Post IDs to prepare.
+	 * @param bool  $is_auto_query Whether the IDs came from the automatic query.
+	 *
+	 * @return array
+	 */
 	abstract protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array;
 
+	/**
+	 * Read the saved query configuration.
+	 *
+	 * @param mixed $block The block instance supplied by the render callback.
+	 */
 	public function __construct( $block ) {
 		$this->block      = (array) $block;
 		$this->query_loop = (array) get_field( Query_Loop::QUERY_LOOP );
 		$this->cta        = [];
 	}
 
+	/**
+	 * Resolve the editor's selection into display-ready items.
+	 *
+	 * Falls back to the latest-posts mode when nothing has been chosen.
+	 *
+	 * @return array
+	 */
 	public function get_items(): array {
 		$query_type = $this->query_loop[ Query_Loop::QUERY_TYPE ] ?? Query_Loop::LATEST;
 
@@ -39,6 +108,11 @@ abstract class Query_Loop_Controller {
 		return $this->get_manual_query_items();
 	}
 
+	/**
+	 * The most recent published posts.
+	 *
+	 * @return array
+	 */
 	protected function get_latest_query_items(): array {
 		$args = [
 			'fields'      => 'ids',
@@ -58,6 +132,14 @@ abstract class Query_Loop_Controller {
 		return $this->prepare_posts_for_display( $posts );
 	}
 
+	/**
+	 * Posts belonging to the chosen taxonomy term.
+	 *
+	 * Optionally excludes the post being viewed, so a related-stories block on
+	 * a post does not list that post.
+	 *
+	 * @return array
+	 */
 	protected function get_automatic_query_items(): array {
 		$category_id = $this->query_loop[ Query_Loop::QUERY_LOOP ][ Query_Loop::TAX_ITEMS ] ?? 0;
 
@@ -97,6 +179,14 @@ abstract class Query_Loop_Controller {
 		return $this->prepare_posts_for_display( $posts );
 	}
 
+	/**
+	 * The editor's hand-picked posts, in the order they were arranged.
+	 *
+	 * Note: the repeater index is read unguarded, so manual mode with no rows
+	 * saved raises a warning. Tracked in #104.
+	 *
+	 * @return array
+	 */
 	protected function get_manual_query_items(): array {
 		$posts = $this->query_loop[ Query_Loop::MANUAL_CARDS ];
 

--- a/src/Components/Related_Stories_Block_Controller.php
+++ b/src/Components/Related_Stories_Block_Controller.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Related stories block controller.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components;
 
@@ -7,13 +14,26 @@ use UCSC\Blocks\Blocks\Query_Loop;
 use UCSC\Blocks\Components\Traits\With_Image_Size;
 use UCSC\Blocks\Components\Traits\With_Primary_Term;
 
+/**
+ * Prepares posts for the Related Stories block.
+ */
 class Related_Stories_Block_Controller extends Query_Loop_Controller {
 
 	use With_Image_Size;
 	use With_Primary_Term;
 
+	/**
+	 * How many posts to display.
+	 *
+	 * @var int
+	 */
 	protected int $number_of_posts_display = 3;
 
+	/**
+	 * The block's wrapper attributes, full-width and constrained.
+	 *
+	 * @return string
+	 */
 	public function get_attributes(): string {
 		$classes = [
 			'ucsc-related-stories-block',
@@ -31,6 +51,16 @@ class Related_Stories_Block_Controller extends Query_Loop_Controller {
 		);
 	}
 
+	/**
+	 * Shape each post into a card.
+	 *
+	 * Falls back to the category taxonomy when none was chosen.
+	 *
+	 * @param array $posts         Post IDs to prepare.
+	 * @param bool  $is_auto_query Whether the IDs came from the automatic query.
+	 *
+	 * @return array
+	 */
 	protected function prepare_posts_for_display( array $posts = [], bool $is_auto_query = false ): array {
 
 		$items = [];
@@ -44,7 +74,7 @@ class Related_Stories_Block_Controller extends Query_Loop_Controller {
 			$image_meta = $image_id > 0 ? wp_get_attachment_metadata( $image_id ) : [];
 			$image_url  = wp_get_attachment_url( $image_id );
 
-			$taxonomy = 'category'; // Default taxonomy
+			$taxonomy = 'category';
 			if ( isset( $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ] ) ) {
 				$taxonomy = $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ];
 			}

--- a/src/Components/Traits/With_CTA.php
+++ b/src/Components/Traits/With_CTA.php
@@ -1,9 +1,33 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Call-to-action rendering.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components\Traits;
 
+/**
+ * Renders the call-to-action link saved by an ACF link field.
+ *
+ * Expects the using class to expose a $cta property holding ACF's link array
+ * of title, url and target.
+ */
 trait With_CTA {
 
+	/**
+	 * Render the call to action as an anchor.
+	 *
+	 * Returns an empty string when no link has been set, or when either the
+	 * title or the URL is missing, so a partially filled field renders nothing
+	 * rather than a broken link.
+	 *
+	 * @param array $classes Classes to apply to the anchor.
+	 *
+	 * @return string The anchor markup, or an empty string.
+	 */
 	public function get_cta( array $classes = [] ): string {
 		if ( empty( $this->cta ) || empty( $this->cta['title'] ) || empty( $this->cta['url'] ) ) {
 			return '';

--- a/src/Components/Traits/With_Image_Size.php
+++ b/src/Components/Traits/With_Image_Size.php
@@ -1,9 +1,32 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Responsive image helper.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components\Traits;
 
+/**
+ * Builds srcset attributes from a remote image payload.
+ *
+ * Used for images that arrive over REST from the news site, where the local
+ * attachment helpers are unavailable because there is no local attachment.
+ */
 trait With_Image_Size {
 
+	/**
+	 * Build a srcset string from an image's available sizes.
+	 *
+	 * Returns an empty string when the image or its sizes are missing, so the
+	 * caller can emit the attribute unconditionally.
+	 *
+	 * @param array $image Image payload, expected to carry 'url' and 'sizes'.
+	 *
+	 * @return string The srcset value, or an empty string.
+	 */
 	public function build_srcset( array $image = [] ): string {
 		if ( empty( $image ) ) {
 			return '';

--- a/src/Components/Traits/With_Primary_Term.php
+++ b/src/Components/Traits/With_Primary_Term.php
@@ -1,25 +1,51 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Primary term resolution.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Components\Traits;
 
 use WP_Term;
 
+/**
+ * Picks the single term to display for a post.
+ *
+ * Posts usually carry several categories, but the card layouts show only one.
+ */
 trait With_Primary_Term {
 
+	/**
+	 * Resolve the term to display for a post.
+	 *
+	 * Prefers the primary term an editor set through Yoast. Without Yoast, or
+	 * without a primary term set, falls back to the post's first term.
+	 *
+	 * On a category archive the current category is avoided where possible, so
+	 * cards in a category listing are not all labelled with that same category.
+	 *
+	 * @param int|null $post_id  Post to inspect; defaults to the current post.
+	 * @param string   $taxonomy Taxonomy to read.
+	 *
+	 * @return WP_Term|null The term to display, or null when the post has none.
+	 */
 	public function get_primary_term( ?int $post_id = null, string $taxonomy = 'category' ): ?WP_Term {
 		$terms = get_the_terms( get_post( $post_id ), $taxonomy );
 
-		// No terms set
+		// No terms set.
 		if ( is_wp_error( $terms ) || empty( $terms ) ) {
 			return null;
 		}
 
-		// Yoast Enabled
+		// Yoast enabled.
 		if ( $this->has_yoast() ) {
 			$primary_term_id = yoast_get_primary_term_id( $taxonomy, $post_id );
 		}
 
-		// No Yoast fallback
+		// No Yoast fallback.
 		if ( empty( $primary_term_id ) ) {
 			$primary_term_id = reset( $terms )->term_id;
 		}
@@ -42,6 +68,11 @@ trait With_Primary_Term {
 		return get_term( $primary_term_id );
 	}
 
+	/**
+	 * Whether Yoast SEO is available to supply a primary term.
+	 *
+	 * @return bool
+	 */
 	protected function has_yoast(): bool {
 		return function_exists( 'yoast_get_primary_term_id' );
 	}


### PR DESCRIPTION
## What does this do/fix?

Step 3 of #116, **slice 3 of 4** — `src/Components/`.

**phpcs: 329 errors → 204.** 14 files.

Covers `Abstract_Controller`, the three shared traits, the `Query_Loop_Controller` base, and all nine concrete controllers.

### Remaining slices

| slice | scope | count |
|---|---|---|
| ~~1~~ | ~~bootstrap + infrastructure~~ | ~~103~~ ✅ #120 |
| ~~2~~ | ~~`src/Blocks/`~~ | ~~117~~ ✅ #121 |
| ~~3~~ | ~~`src/Components/`~~ | ~~125~~ ✅ this PR |
| 4 | `src/Template/` + `src/views/` | 51 |

## Why this slice reads differently

The field groups in slice 2 were declarative — arrays describing an editor UI. Controllers are where the plugin's behaviour actually lives, so these docblocks try to answer things the signature cannot:

- **`Query_Loop_Controller`** — how the three editor modes each resolve to a list of post IDs, and where the subclass takes over.
- **`With_Primary_Term`** — that on a category archive it deliberately avoids the current category, so a listing's cards aren't all labelled with the category you're already viewing. That behaviour is non-obvious and easy to "fix" by accident.
- **`News_Block_Controller`** — that its content is remote, and where each of its four separate caches comes from.
- **`Post_Header_Block_Controller`** — that the image caption and credit are read from the attachment's `post_excerpt` and `post_content`, which is where WordPress puts them but not where you'd look first.

Accessors say what they return when nothing is configured, since almost every one of them has an empty-state path that the views rely on.

## Docblocks name open bugs rather than blessing them

| location | note | issue |
|---|---|---|
| `Query_Loop_Controller::get_manual_query_items()` | repeater index read unguarded | #104 |
| `News_Block_Controller` class doc | N+1 blocking remote calls on cold render | #107 |
| `News_Block_Controller::get_cache_key()` | keys embed term IDs, so per-object caches fragment | #107 |
| `News_Block_Controller::$posts_per_page` | resolves to `0` for blocks predating the field | #106 |

## Two incidental tidies

Both were forced by phpcs rather than chosen:

- Removed two trailing comments in `News_Block_Controller` (`// Fetch data using the constant PER_PAGE for the API request`, `// Use the constant here`) that restated the line they sat on and tripped a punctuation sniff.
- Normalised assignment spacing on `$post_types` in two controllers. Those properties were aligned as a group with the line above; inserting docblocks between them split the group and left the old padding reported as a misalignment.

## Tests

```bash
composer lint    # 204 errors, 14 warnings — down from 329 / 14
npm run build    # green
```

Verified locally:

- [x] All 14 changed files pass `php -l`
- [x] Zero documentation violations remain in `src/Components/`
- [x] Warning count back to its starting value — the two the docblocks introduced are fixed, not left behind
- [x] **Documentation-only**: token streams compared with comments stripped and open-tag whitespace normalised — executable code identical across all 14 files
- [x] `npm run build` green

The 12 errors still reported in `src/Components/` are unrelated style rules — Yoda conditions and short ternaries — and belong to the long tail in #116, step 5.

Reviewer checks — prose, so it wants reading:

- [ ] The three query modes in `Query_Loop_Controller` are described accurately
- [ ] `With_Primary_Term`'s archive behaviour matches intent — this is the one most worth a second opinion
- [ ] `News_Block_Controller`'s caching description matches what you understand it to do
- [ ] Nothing reads as confidently wrong
