### PR TITLE
docs: add docblocks to templates and views (slice 4/4)

### DIFF
--- a/src/Template/Blocks_Render.php
+++ b/src/Template/Blocks_Render.php
@@ -1,11 +1,36 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Core block output filtering.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Template;
 
+/**
+ * Rewrites the output of core blocks used in the custom templates.
+ *
+ * These adjustments cannot be made in the templates themselves, because the
+ * blocks being changed are core blocks whose markup the plugin does not
+ * own. Each method returns the content untouched unless it recognises the
+ * block, so the filter is safe to run against every block on the page.
+ */
 class Blocks_Render {
 
+	/**
+	 * The single instance.
+	 *
+	 * @var self
+	 */
 	private static self $instance;
 
+	/**
+	 * Get the singleton instance, creating it on first call.
+	 *
+	 * @return self
+	 */
 	public static function instance(): self {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new self();
@@ -14,6 +39,16 @@ class Blocks_Render {
 		return self::$instance;
 	}
 
+	/**
+	 * Replace the core author name with the Co-Authors Plus byline.
+	 *
+	 * Falls through untouched when Co-Authors Plus is not active.
+	 *
+	 * @param string $block_content The rendered block.
+	 * @param array  $block         The parsed block.
+	 *
+	 * @return string
+	 */
 	public function adjust_author_block( $block_content = '', $block = [] ) {
 		if ( ! is_singular() || ! function_exists( 'coauthors_posts_links' ) || ! ( isset( $block['blockName'] ) && 'core/post-author-name' === $block['blockName'] ) ) {
 			return $block_content;
@@ -28,6 +63,16 @@ class Blocks_Render {
 		);
 	}
 
+	/**
+	 * Append the featured image's caption and credit.
+	 *
+	 * The credit is stored in the attachment's post content.
+	 *
+	 * @param string $block_content The rendered block.
+	 * @param array  $block         The parsed block.
+	 *
+	 * @return string
+	 */
 	public function adjust_featured_image_block( $block_content = '', $block = [] ) {
 		if ( ! is_singular() || ! ( isset( $block['blockName'] ) && 'core/post-featured-image' === $block['blockName'] ) ) {
 			return $block_content;
@@ -49,6 +94,14 @@ class Blocks_Render {
 		return $block_content;
 	}
 
+	/**
+	 * Wrap the post terms in a titled "Related Topics" section.
+	 *
+	 * @param string $block_content The rendered block.
+	 * @param array  $block         The parsed block.
+	 *
+	 * @return string
+	 */
 	public function adjust_post_terms_block( $block_content = '', $block = [] ) {
 		if ( ! is_single() || ! ( isset( $block['blockName'] ) && 'core/post-terms' === $block['blockName'] ) ) {
 			return $block_content;
@@ -63,6 +116,14 @@ class Blocks_Render {
 		return $block_content;
 	}
 
+	/**
+	 * Wrap the sharing links in a titled "Share" section.
+	 *
+	 * @param string $block_content The rendered block.
+	 * @param array  $block         The parsed block.
+	 *
+	 * @return string
+	 */
 	public function adjust_social_share_block( $block_content = '', $block = [] ) {
 		if ( ! is_singular() || ! ( isset( $block['blockName'] ) && 'outermost/social-sharing' === $block['blockName'] ) ) {
 			return $block_content;

--- a/src/Template/Patterns/Pattern.php
+++ b/src/Template/Patterns/Pattern.php
@@ -1,16 +1,54 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Block pattern base class.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Template\Patterns;
 
+/**
+ * Base for block patterns registered by the plugin.
+ *
+ * Currently has no concrete subclasses; kept as the extension point for
+ * patterns registered alongside the custom templates.
+ */
 abstract class Pattern {
 
-	public const SLUG      = '';
+	/**
+	 * Pattern slug. Overridden per subclass.
+	 *
+	 * @var string
+	 */
+	public const SLUG = '';
+	/**
+	 * Pattern namespace.
+	 *
+	 * @var string
+	 */
 	public const NAMESPACE = 'ucsc-custom-functionality';
 
+	/**
+	 * Arguments passed to register_block_pattern().
+	 *
+	 * @return array
+	 */
 	abstract public function get_args(): array;
 
+	/**
+	 * Register the pattern.
+	 *
+	 * @return void
+	 */
 	abstract public function register(): void;
 
+	/**
+	 * Compose the namespaced pattern name.
+	 *
+	 * @return string
+	 */
 	protected function build_pattern_name(): string {
 		return sprintf( '%s/%s', self::NAMESPACE, static::SLUG );
 	}

--- a/src/Template/Photo_Of_The_Week_Archive.php
+++ b/src/Template/Photo_Of_The_Week_Archive.php
@@ -1,16 +1,50 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week archive block template.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Template;
 
 use UCSC\Blocks\Post_Types\Photo_Of_The_Week\Photo_Of_The_Week;
 use WP_Block_Template;
 
+/**
+ * Injects the custom Photo of the Week archive template.
+ */
 class Photo_Of_The_Week_Archive extends Template {
 
-	public const NAME    = 'photo_of_the_week_archive';
-	public const SLUG    = 'photo-of-the-week-archive';
+	/**
+	 * Identifier for the template.
+	 *
+	 * @var string
+	 */
+	public const NAME = 'photo_of_the_week_archive';
+	/**
+	 * Template slug.
+	 *
+	 * @var string
+	 */
+	public const SLUG = 'photo-of-the-week-archive';
+	/**
+	 * Template version.
+	 *
+	 * @var string
+	 */
 	public const VERSION = '1.0.1';
 
+	/**
+	 * Return this template when the Photo of the Week archive is viewed.
+	 *
+	 * @param mixed  $query_result  Templates found so far.
+	 * @param array  $query         The template query.
+	 * @param string $template_type The template type being queried.
+	 *
+	 * @return mixed
+	 */
 	public function register( $query_result, $query, $template_type ) {
 		$template = $this->register_template();
 
@@ -21,6 +55,11 @@ class Photo_Of_The_Week_Archive extends Template {
 		return $template;
 	}
 
+	/**
+	 * Create the wp_template post from the bundled HTML.
+	 *
+	 * @return WP_Block_Template|null
+	 */
 	protected function create_wp_block_template(): ?WP_Block_Template {
 		$post_title   = esc_html__( 'Photo of the Week', 'ucsc' );
 		$post_excerpt = esc_html__( 'Photo of the Week archive page', 'ucsc' );

--- a/src/Template/Post_Single.php
+++ b/src/Template/Post_Single.php
@@ -1,15 +1,55 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Single post block template.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Template;
 
 use WP_Block_Template;
 
+/**
+ * Injects the custom single-post template.
+ *
+ * Applies to single posts only, and steps aside for post embeds, which
+ * request their own template through the same filter.
+ */
 class Post_Single extends Template {
 
-	public const NAME    = 'ucsc_post_single_template';
-	public const SLUG    = 'post-single';
+	/**
+	 * Identifier for the template.
+	 *
+	 * @var string
+	 */
+	public const NAME = 'ucsc_post_single_template';
+	/**
+	 * Template slug.
+	 *
+	 * @var string
+	 */
+	public const SLUG = 'post-single';
+	/**
+	 * Template version.
+	 *
+	 * @var string
+	 */
 	public const VERSION = '1.0';
 
+	/**
+	 * Return this template when a single post is being viewed.
+	 *
+	 * Note: $query['slug__in'] is read unguarded, and callers frequently omit
+	 * it. Tracked in #104.
+	 *
+	 * @param mixed  $query_result  Templates found so far.
+	 * @param array  $query         The template query.
+	 * @param string $template_type The template type being queried.
+	 *
+	 * @return mixed
+	 */
 	public function register( $query_result, $query, $template_type ) {
 		$template = $this->register_template();
 
@@ -20,6 +60,11 @@ class Post_Single extends Template {
 		return $template;
 	}
 
+	/**
+	 * Create the wp_template post from the bundled HTML.
+	 *
+	 * @return WP_Block_Template|null
+	 */
 	protected function create_wp_block_template(): ?WP_Block_Template {
 		$post_title   = esc_html__( 'UCSC Single Posts', 'ucsc' );
 		$post_excerpt = esc_html__( 'Displays a single post with a heading, press coverage, categories, social sharing, and related stories.', 'ucsc' );

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -1,4 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Block template base class.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Template;
 
@@ -6,17 +13,67 @@ use WP_Block_Template;
 use WP_Post;
 use WP_Query;
 
+/**
+ * Base for the block templates the plugin injects into the Site Editor.
+ *
+ * These templates are not theme files. On first request the subclass writes
+ * a wp_template post from an HTML file in src/views/templates/ and tags it
+ * with a wp_theme term, after which WordPress treats it as a user-created
+ * template that editors can modify.
+ *
+ * Because that term is the theme slug, the templates are bound to one theme;
+ * renaming or switching themes orphans them silently. See #109.
+ */
 abstract class Template {
 
-	public const NAME      = '';
-	public const SLUG      = '';
+	/**
+	 * Identifier for the template. Overridden per subclass.
+	 *
+	 * @var string
+	 */
+	public const NAME = '';
+	/**
+	 * Template slug, used as the wp_template post name.
+	 *
+	 * @var string
+	 */
+	public const SLUG = '';
+	/**
+	 * The wp_theme term templates are filed under.
+	 *
+	 * Hardcoded to the UCSC theme slug; see #109.
+	 *
+	 * @var string
+	 */
 	public const NAMESPACE = 'ucsc-2022';
 
-	public const VERSION          = '';
+	/**
+	 * Template version. Overridden per subclass.
+	 *
+	 * @var string
+	 */
+	public const VERSION = '';
+	/**
+	 * Meta key reserved for storing a template's version.
+	 *
+	 * @var string
+	 */
 	public const TEMPLATE_VERSION = 'ucsc_template_version';
 
+	/**
+	 * Create the wp_template post backing this template.
+	 *
+	 * Called once, on first request.
+	 *
+	 * @return WP_Block_Template|null
+	 */
 	abstract protected function create_wp_block_template(): ?WP_Block_Template;
 
+	/**
+	 * Hook the template into the Site Editor's template lookup.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 		add_filter(
 			'get_block_templates',
@@ -28,16 +85,44 @@ abstract class Template {
 		);
 	}
 
+	/**
+	 * The template's slug, used as the post name.
+	 *
+	 * @return string
+	 */
 	public function get_slug(): string {
 		return static::SLUG;
 	}
 
+	/**
+	 * The wp_theme term the template is filed under.
+	 *
+	 * @return string
+	 */
 	public function get_namespace(): string {
 		return static::NAMESPACE;
 	}
 
+	/**
+	 * Decide whether this template applies to the current request.
+	 *
+	 * Implemented per template.
+	 *
+	 * @param mixed  $query_result  Templates found so far.
+	 * @param array  $query         The template query.
+	 * @param string $template_type The template type being queried.
+	 *
+	 * @return mixed
+	 */
 	abstract public function register( $query_result, $query, $template_type );
 
+	/**
+	 * Find the stored template, creating it on first use.
+	 *
+	 * Returns null when the template could not be created.
+	 *
+	 * @return array|null
+	 */
 	public function register_template() {
 		$wp_block_template = $this->find_block_template_by_post( $this->get_slug(), $this->get_namespace() );
 
@@ -54,6 +139,16 @@ abstract class Template {
 	}
 
 
+	/**
+	 * Build a WP_Block_Template from its stored post.
+	 *
+	 * Returns null when the post carries no wp_theme term, since without one
+	 * the template cannot be addressed.
+	 *
+	 * @param WP_Post $post The stored wp_template post.
+	 *
+	 * @return WP_Block_Template|null
+	 */
 	public function hydrate_block_template_by_post( WP_Post $post ): ?WP_Block_Template {
 		$terms = get_the_terms( $post, 'wp_theme' );
 
@@ -82,6 +177,14 @@ abstract class Template {
 		return $template;
 	}
 
+	/**
+	 * Look up a stored template by slug and theme term.
+	 *
+	 * @param string $post_name The template slug.
+	 * @param string $terms     The wp_theme term name.
+	 *
+	 * @return WP_Block_Template|null
+	 */
 	protected function find_block_template_by_post( string $post_name, string $terms = '' ): ?WP_Block_Template {
 		$wp_query_args  = [
 			'post_name__in'  => [ $post_name ],

--- a/src/Template/Template_Subscriber.php
+++ b/src/Template/Template_Subscriber.php
@@ -1,9 +1,31 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Template hook registration.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 namespace UCSC\Blocks\Template;
 
+/**
+ * Wires up the template-related filters on news sites.
+ *
+ * Two jobs: routing every rendered block through Blocks_Render, and giving
+ * new posts a starting block structure so editors begin from the intended
+ * layout rather than an empty canvas.
+ */
 class Template_Subscriber {
 
+	/**
+	 * Register the block render filter and the default post template.
+	 *
+	 * The render filter runs late, at priority 100, so it sees output other
+	 * filters have already produced.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 		$block_renderer = Blocks_Render::instance();
 

--- a/src/views/featured-news-block/index.php
+++ b/src/views/featured-news-block/index.php
@@ -1,9 +1,23 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Featured Stories block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Components\Featured_News_Block_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c = new Featured_News_Block_Controller( $block );
 

--- a/src/views/magazine-block/index.php
+++ b/src/views/magazine-block/index.php
@@ -1,10 +1,24 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * UCSC Magazine block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Blocks\Magazine_Block;
 use UCSC\Blocks\Components\Magazine_Block_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c         = new Magazine_Block_Controller( $block );
 $title_1   = $c->get_title_line_1();

--- a/src/views/media-coverage-block/index.php
+++ b/src/views/media-coverage-block/index.php
@@ -1,9 +1,23 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Media Coverage block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Components\Media_Coverage_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c = new Media_Coverage_Controller( $block );
 

--- a/src/views/news-block/index.php
+++ b/src/views/news-block/index.php
@@ -1,7 +1,21 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * News block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c = new \UCSC\Blocks\Components\News_Block_Controller( $block );
 

--- a/src/views/photo-of-the-week-block/index.php
+++ b/src/views/photo-of-the-week-block/index.php
@@ -1,9 +1,23 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Components\Photo_Of_The_Week_Block_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c     = new Photo_Of_The_Week_Block_Controller( $block );
 $photo = $c->get_photo();

--- a/src/views/photos-week-loop/index.php
+++ b/src/views/photos-week-loop/index.php
@@ -1,4 +1,16 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Photo of the Week archive loop view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Components\Photo_Of_The_Week_Archive_Controller;
 use UCSC\Blocks\Object_Meta\Photo_Of_The_Week_Meta;

--- a/src/views/post-header-block/index.php
+++ b/src/views/post-header-block/index.php
@@ -1,9 +1,23 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Post Header block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Components\Post_Header_Block_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c            = new Post_Header_Block_Controller( $block );
 $primary_term = $c->get_primary_category();

--- a/src/views/press-inquiries/index.php
+++ b/src/views/press-inquiries/index.php
@@ -1,10 +1,24 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Press Inquiries block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Blocks\Press_Inquiries_Block;
 use UCSC\Blocks\Components\Press_Inquiries_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c           = new Press_Inquiries_Controller( $block );
 $contacts    = $c->get_press_contacts();

--- a/src/views/related-stories-block/index.php
+++ b/src/views/related-stories-block/index.php
@@ -1,9 +1,23 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Related Stories block view.
+ *
+ * Rendered by Core::render_template(). Although the block is registered
+ * from build/views/, that path is rewritten back to src/views/ before the
+ * template is included — so edits here take effect without a rebuild, and
+ * the copy webpack emits into build/ is never executed.
+ *
+ * @package ucsc
+ */
+
+declare(strict_types=1);
 
 use UCSC\Blocks\Components\Related_Stories_Block_Controller;
 
 /**
- * @var array $block current block attributes
+ * The block instance supplied by the render callback.
+ *
+ * @var array $block Current block attributes.
  */
 $c = new Related_Stories_Block_Controller( $block );
 


### PR DESCRIPTION
## What does this do/fix?

Step 3 of #116, **slice 4 of 4** — `src/Template/` and `src/views/`.

**phpcs: 204 errors → 153.** 15 files.

**This completes step 3.** Zero documentation violations remain anywhere in the repository, down from 396 when #101 first made the linters run.

| slice | scope | count |
|---|---|---|
| ~~1~~ | ~~bootstrap + infrastructure~~ | ~~103~~ ✅ #120 |
| ~~2~~ | ~~`src/Blocks/`~~ | ~~117~~ ✅ #121 |
| ~~3~~ | ~~`src/Components/`~~ | ~~125~~ ✅ #124 |
| ~~4~~ | ~~`src/Template/` + `src/views/`~~ | ~~51~~ ✅ this PR |

Covers the `Template` base and its two concrete templates, `Blocks_Render`, `Template_Subscriber`, the `Pattern` base, and all nine block view templates.

## Why this slice matters most

The template layer is the least self-evident part of the plugin — three separate mechanisms that are not obvious from reading any single file:

- **`Template`** — these are *not* theme files. On first request a `wp_template` post is written from bundled HTML in `src/views/templates/` and tagged with a `wp_theme` term, after which WordPress treats it as a user-created template that editors can modify. Nothing in the class name says that.
- **`Blocks_Render`** — why core block output is filtered at all (the plugin doesn't own that markup, so it can't be changed in the template), and why every method is a deliberate no-op for blocks it doesn't recognise, since the filter runs against every block on the page.
- **`views/*/index.php`** — that `Core::render_template()` rewrites `build/views/` back to `src/views/` before including, so **edits to these files take effect without a rebuild**, and the copy webpack emits into `build/` is never executed. This one has real day-to-day consequences and is invisible from the file itself.

## Docblocks name open bugs rather than blessing them

| location | note | issue |
|---|---|---|
| `Template::NAMESPACE` | hardcoded `ucsc-2022` theme slug; theme rename orphans templates | #109 |
| `Post_Single::register()` | `$query['slug__in']` read unguarded | #104 |

One observation recorded, not acted on: `Template\Patterns\Pattern` has no concrete subclasses. Documented as the extension point it appears to be, rather than removed — that's a judgement call for someone who knows whether patterns are still planned.

## Tests

```bash
composer lint    # 153 errors, down from 204
npm run build    # green
```

Verified locally:

- [x] All 15 changed files pass `php -l`
- [x] **Zero documentation violations remain repo-wide** (was 396)
- [x] Warning count unchanged at 14
- [x] **Documentation-only**: token streams compared with comments stripped, open-tag whitespace normalised, and inline HTML normalised — executable code identical across all 15 files
- [x] `npm run build` green

The views mix PHP and HTML, so the token comparison normalises `T_INLINE_HTML` too — meaning the rendered markup is provably unchanged, not just the PHP.

Reviewer checks:

- [ ] The `Template` class description matches how you understand template injection to work
- [ ] The `build/` → `src/` rewrite note on the views is accurate — this is the claim most worth confirming, since people will rely on it
- [ ] Blocks still render on a news site (the views were touched, even if only in their headers)

## What remains on #116

| step | scope | count |
|---|---|---|
| ~~1~~ | ~~phpcbf mechanical~~ | ✅ #118 |
| ~~2~~ | ~~eslint mechanical~~ | ✅ #119 |
| ~~3~~ | ~~docblocks~~ | ✅ slices 1–4 |
| 4 | `WordPress.Security.EscapeOutput` | 80 |
| 5 | long tail (Yoda conditions, short ternaries, etc.) | ~73 |
| — | eslint `no-unused-vars` + missing JSDoc return | 2 |

Step 4 is the one with real security relevance and is the natural next move.
