### PR TITLE
fix: escape all block view output (80 EscapeOutput findings)

### DIFF
--- a/src/Components/Magazine_Block_Controller.php
+++ b/src/Components/Magazine_Block_Controller.php
@@ -143,6 +143,10 @@ class Magazine_Block_Controller {
 	 *
 	 * Returns nothing unless both a title and a URL were entered.
 	 *
+	 * Values are returned raw; the view escapes them for its context. Escaping
+	 * here as well would double-encode entities, so a title like
+	 * "Arts & Sciences" would render as "Arts &amp; Sciences".
+	 *
 	 * @param array $magazine The item.
 	 *
 	 * @return array
@@ -153,14 +157,16 @@ class Magazine_Block_Controller {
 		}
 
 		return [
-			'title'  => esc_html( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['title'] ),
-			'url'    => esc_url( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['url'] ),
-			'target' => esc_attr( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['target'] ?: '_self' ),
+			'title'  => $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['title'],
+			'url'    => $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['url'],
+			'target' => ! empty( $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['target'] ) ? $magazine[ Magazine_Block::ITEM_CTA_FIELD ]['target'] : '_self',
 		];
 	}
 
 	/**
 	 * An item's image as responsive markup, or an empty string.
+	 *
+	 * The returned markup is fully escaped, so callers may echo it directly.
 	 *
 	 * @param array $magazine The item.
 	 *
@@ -176,21 +182,20 @@ class Magazine_Block_Controller {
 		$image_url  = wp_get_attachment_url( $image_id );
 
 		return sprintf(
-			'<img 
-				src="%s" 
-				srcset="%s" 
-				class="" 
-			/>',
-			$image_url,
-			$this->build_srcset(
-				array_merge(
-					[
-						'id'  => $image_id,
-						'url' => $image_url,
-					],
-					$image_meta
+			'<img src="%s" srcset="%s" alt="%s" />',
+			esc_url( $image_url ),
+			esc_attr(
+				$this->build_srcset(
+					array_merge(
+						[
+							'id'  => $image_id,
+							'url' => $image_url,
+						],
+						$image_meta
+					)
 				)
-			)
+			),
+			esc_attr( (string) get_post_meta( $image_id, '_wp_attachment_image_alt', true ) )
 		);
 	}
 

--- a/src/Components/Photo_Of_The_Week_Archive_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Archive_Controller.php
@@ -62,6 +62,8 @@ class Photo_Of_The_Week_Archive_Controller {
 	/**
 	 * The current photo as responsive markup, or an empty string.
 	 *
+	 * The returned markup is fully escaped, so callers may echo it directly.
+	 *
 	 * @return string
 	 */
 	public function render_image(): string {
@@ -83,9 +85,9 @@ class Photo_Of_The_Week_Archive_Controller {
 
 		return sprintf(
 			'<img src="%s" srcset="%s" alt="%s" class="photo-of-the-week__image" />',
-			$image['url'],
-			$this->build_srcset( $image_data ),
-			get_the_title( get_the_ID() )
+			esc_url( $image['url'] ),
+			esc_attr( $this->build_srcset( $image_data ) ),
+			esc_attr( get_the_title( get_the_ID() ) )
 		);
 	}
 

--- a/src/Components/Photo_Of_The_Week_Block_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Block_Controller.php
@@ -88,6 +88,8 @@ class Photo_Of_The_Week_Block_Controller {
 	 * The featured photo, or null when none is selected.
 	 *
 	 * Bundles the rendered markup, a download URL, the title and the credit.
+	 * The 'image' member is fully escaped markup; the other members are raw
+	 * values that callers must escape themselves.
 	 *
 	 * @return array|null
 	 */
@@ -103,9 +105,9 @@ class Photo_Of_The_Week_Block_Controller {
 		if ( ! empty( $image_data ) ) {
 			$image = sprintf(
 				'<img src="%s" srcset="%s" alt="%s" class="photo-of-the-week__image" />',
-				$image_data['url'],
-				$this->build_srcset( $image_data ),
-				get_the_title( get_the_ID() )
+				esc_url( $image_data['url'] ),
+				esc_attr( $this->build_srcset( $image_data ) ),
+				esc_attr( get_the_title( get_the_ID() ) )
 			);
 		}
 

--- a/src/Components/Traits/With_CTA.php
+++ b/src/Components/Traits/With_CTA.php
@@ -24,6 +24,8 @@ trait With_CTA {
 	 * title or the URL is missing, so a partially filled field renders nothing
 	 * rather than a broken link.
 	 *
+	 * The returned markup is fully escaped, so callers may echo it directly.
+	 *
 	 * @param array $classes Classes to apply to the anchor.
 	 *
 	 * @return string The anchor markup, or an empty string.
@@ -33,8 +35,14 @@ trait With_CTA {
 			return '';
 		}
 
-		$classes = ! empty( $classes ) ? sprintf( 'class="%s"', implode( ' ', $classes ) ) : '';
+		$classes = ! empty( $classes ) ? sprintf( 'class="%s"', esc_attr( implode( ' ', $classes ) ) ) : '';
 
-		return sprintf( '<a href="%s"%s target="%s">%s</a>', $this->cta['url'], $classes, $this->cta['target'] ?: '_self', $this->cta['title'] );
+		return sprintf(
+			'<a href="%s"%s target="%s">%s</a>',
+			esc_url( $this->cta['url'] ),
+			$classes,
+			esc_attr( ! empty( $this->cta['target'] ) ? $this->cta['target'] : '_self' ),
+			esc_html( $this->cta['title'] )
+		);
 	}
 }

--- a/src/views/featured-news-block/index.php
+++ b/src/views/featured-news-block/index.php
@@ -45,33 +45,33 @@ if ( empty( $items ) && is_admin() ) {
 						<?php $image_alt = get_post_meta( $item['image']['id'], '_wp_attachment_image_alt', true ); ?>
 						<img 
 							src="<?php echo esc_url( $item['image']['url'] ); ?>" 
-							srcset="<?php echo $c->build_srcset( $item['image'] ); ?>" 
+							srcset="<?php echo esc_attr( $c->build_srcset( $item['image'] ) ); ?>" 
 							class="ucsc-featured-news-block__featured-image"
-							alt="<?php echo ! empty( $image_alt ) ? esc_attr( get_post_meta( $item['image']['id'], '_wp_attachment_image_alt' )[0] ) : $item['title']; ?>"
+							alt="<?php echo esc_attr( ! empty( $image_alt ) ? $image_alt : $item['title'] ); ?>"
 						/>
 					</div>
 				<?php endif; ?>
 				<?php if ( ! empty( $item['category'] ) ) : ?>
 					<span class="ucsc-featured-news-block__category">
-						<?php echo $item['category']->name; ?>
+						<?php echo esc_html( $item['category']->name ); ?>
 					</span>
 				<?php endif; ?>
 	
 				<h2 class="ucsc-featured-news-block__card-title">
 					<span class="ucsc-featured-news-block__card-title--inner">
-						<?php echo $item['title']; ?>
+						<?php echo esc_html( $item['title'] ); ?>
 					</span>
 				</h2>
 	
 				<?php if ( $key === 0 && ! empty( $item['excerpt'] ) ) : ?>
-					<p class="ucsc-featured-news-block__card-excerpt"><?php echo $item['excerpt']; ?></p>
+					<p class="ucsc-featured-news-block__card-excerpt"><?php echo wp_kses_post( $item['excerpt'] ); ?></p>
 				<?php endif; ?>
 			</a>
 		<?php endforeach; ?>
 		
 		<?php if ( $c->get_cta() ) : ?>
 			<div class="ucsc-featured-news-block__cta is-style-ucsc-blue">
-				<?php echo $c->get_cta( [ 'wp-element-button' ] ); ?>
+				<?php echo $c->get_cta( [ 'wp-element-button' ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by With_CTA::get_cta(). ?>
 			</div>
 		<?php endif; ?>
 	</div>

--- a/src/views/magazine-block/index.php
+++ b/src/views/magazine-block/index.php
@@ -26,27 +26,27 @@ $title_2   = $c->get_title_line_2();
 $subtitle  = $c->get_subtitle();
 $magazines = $c->get_magazines();
 ?>
-<section <?php echo $c->get_attributes(); ?>>
+<section <?php echo $c->get_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Abstract_Controller::get_attributes(). ?>>
 	<div class="ucsc-magazine-block__inner">
 		<header class="ucsc-magazine-block__header">
 			<?php if ( ! empty( $title_1 ) || ! empty( $title_2 ) ) : ?>
 			<h2 class="ucsc-magazine-block__title">
 				<?php if ( ! empty( $title_1 ) ) : ?>
 				<span class="ucsc-magazine-block__title-line-1 has-four-font-size">
-					<?php echo $title_1; ?>
+					<?php echo esc_html( $title_1 ); ?>
 				</span>
 				<?php endif; ?>
 
 				<?php if ( ! empty( $title_2 ) ) : ?>
 				<span class="ucsc-magazine-block__title-line-2 has-six-font-size">
-					<?php echo $title_2; ?>
+					<?php echo esc_html( $title_2 ); ?>
 				</span>
 				<?php endif; ?>
 			</h2>
 			<?php endif; ?>
 
 			<?php if ( ! empty( $subtitle ) ) : ?>
-			<p class="ucsc-magazine-block__subtitle has-one-font-size"><?php echo $subtitle; ?></p>
+			<p class="ucsc-magazine-block__subtitle has-one-font-size"><?php echo esc_html( $subtitle ); ?></p>
 			<?php endif; ?>
 
 			<div class="ucsc-magazine-block__tabs" role="tablist">
@@ -56,17 +56,17 @@ $magazines = $c->get_magazines();
 					type="button"
 					role="tab"
 					tabindex="-1"
-					data-key="<?php echo $c->make_tab_key( $magazine, $index ); ?>"
-					aria-labelledby="<?php echo $c->make_tab_key( $magazine, $index, 'label' ); ?>"
+					data-key="<?php echo esc_attr( $c->make_tab_key( $magazine, $index ) ); ?>"
+					aria-labelledby="<?php echo esc_attr( $c->make_tab_key( $magazine, $index, 'label' ) ); ?>"
 					aria-selected="false"
-					aria-controls="<?php echo $c->make_tab_key( $magazine, $index, 'panel' ); ?>"
+					aria-controls="<?php echo esc_attr( $c->make_tab_key( $magazine, $index, 'panel' ) ); ?>"
 				>
-					<span id="<?php echo $c->make_tab_key( $magazine, $index, 'label' ); ?>" class="ucsc-magazine-block__post-title">
-						<?php echo $magazine[ Magazine_Block::ITEM_TITLE ]; ?>
+					<span id="<?php echo esc_attr( $c->make_tab_key( $magazine, $index, 'label' ) ); ?>" class="ucsc-magazine-block__post-title">
+						<?php echo esc_html( $magazine[ Magazine_Block::ITEM_TITLE ] ); ?>
 					</span>
 					<?php if ( $magazine[ Magazine_Block::ITEM_BYLINE ] ) : ?>
 					<span class="ucsc-magazine-block__post-author has-base-font-size">
-						<?php echo $magazine[ Magazine_Block::ITEM_BYLINE ]; ?>
+						<?php echo esc_html( $magazine[ Magazine_Block::ITEM_BYLINE ] ); ?>
 					</span>
 					<?php endif; ?>
 				</button>
@@ -77,14 +77,14 @@ $magazines = $c->get_magazines();
 		<div class="ucsc-magazine-block__panels">
 			<?php foreach ( $magazines as $index => $magazine ) : ?>
 			<div
-				id="<?php echo $c->make_tab_key( $magazine, $index, 'panel' ); ?>"
+				id="<?php echo esc_attr( $c->make_tab_key( $magazine, $index, 'panel' ) ); ?>"
 				role="tabpanel"
-				aria-labelledby="<?php echo $c->make_tab_key( $magazine, $index, 'label' ); ?>"
+				aria-labelledby="<?php echo esc_attr( $c->make_tab_key( $magazine, $index, 'label' ) ); ?>"
 				aria-hidden="true"
 				inert
 				class="ucsc-magazine-block__panel"
 			>
-				<?php echo $c->get_image( $magazine ); ?>
+				<?php echo $c->get_image( $magazine ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped markup built by Magazine_Block_Controller::get_image(). ?>
 
 				<?php $cta = $c->get_cta( $magazine ); ?>
 				<?php $description = $c->get_description( $magazine ); ?>
@@ -92,14 +92,14 @@ $magazines = $c->get_magazines();
 				<div class="ucsc-magazine-block__post-excerpt">
 					<?php if ( $description ) : ?>
 					<p>
-						<?php echo $description; ?>
+						<?php echo wp_kses_post( $description ); ?>
 					</p>
 					<?php endif; ?>
 
 					<?php if ( $cta ) : ?>
 					<div class="ucsc-magazine-block__post-cta is-style-ucsc-blue">
-						<a href="<?php echo $cta['url']; ?>" target="<?php echo $cta['target']; ?>" class="wp-element-button">
-							<?php echo $cta['title']; ?>
+						<a href="<?php echo esc_url( $cta['url'] ); ?>" target="<?php echo esc_attr( $cta['target'] ); ?>" class="wp-element-button">
+							<?php echo esc_html( $cta['title'] ); ?>
 							<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none">
 								<path d="M0.767045 9.84203L0 9.08138L7.86222 1.21277H1.57244L1.58523 0.158081H9.67756V8.2632H8.61009L8.62287 1.97981L0.767045 9.84203Z" fill="currentColor"/>
 							</svg>

--- a/src/views/media-coverage-block/index.php
+++ b/src/views/media-coverage-block/index.php
@@ -24,31 +24,31 @@ $c = new Media_Coverage_Controller( $block );
 $items = $c->get_items();
 $title = $c->get_title();
 ?>
-<section <?php echo $c->get_attributes(); ?>>
+<section <?php echo $c->get_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Abstract_Controller::get_attributes(). ?>>
 	<?php if ( ! empty( $title ) ) : ?>
 	<h2 class="ucsc-media-coverage-block__title has-ucsc-primary-blue-color has-five-font-size">
-		<?php echo $title; ?>
+		<?php echo esc_html( $title ); ?>
 	</h2>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $items ) ) : ?>
 	<div class="ucsc-media-coverage-block__grid">
 		<?php foreach ( $items as $item ) : ?>
-		<a class="ucsc-media-coverage-block__post" href="<?php echo $item['source_url']; ?>"<?php echo ! $c->is_internal_url( $item['source_url'] ) ? ' target="_blank" rel="nofollow"' : ''; ?>>
+		<a class="ucsc-media-coverage-block__post" href="<?php echo esc_url( $item['source_url'] ); ?>"<?php echo ! $c->is_internal_url( $item['source_url'] ) ? ' target="_blank" rel="nofollow"' : ''; ?>>
 			<?php if ( ! empty( $item['image'] ) && $item['image']['id'] > 0 ) : ?>
 			<img
 				src="<?php echo esc_url( $item['image']['url'] ); ?>"
-				srcset="<?php echo $c->build_srcset( $item['image'] ); ?>"
+				srcset="<?php echo esc_attr( $c->build_srcset( $item['image'] ) ); ?>"
 				class="ucsc-featured-block__card-image"
 			/>
 			<?php endif; ?>
 
 			<h3>
 				<small class="ucsc-media-coverage-block__post-source has-base-font-size has-dark-gray-color">
-					<?php echo $item['source_title']; ?>
+					<?php echo esc_html( $item['source_title'] ); ?>
 				</small>
 				<span class="ucsc-media-coverage-block__post-title has-two-font-size">
-					<?php echo $item['title']; ?><svg width="16" height="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+					<?php echo esc_html( $item['title'] ); ?><svg width="16" height="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
 						<path d="M4 3h9v9M3 13 13 3"/>
 					</svg>
 				</span>
@@ -64,7 +64,7 @@ $title = $c->get_title();
 
 	<?php if ( $c->get_cta() ) : ?>
 		<div class="ucsc-media-coverage-block__cta is-style-ucsc-blue">
-			<?php echo $c->get_cta( [ 'wp-element-button' ] ); ?>
+			<?php echo $c->get_cta( [ 'wp-element-button' ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by With_CTA::get_cta(). ?>
 		</div>
 	<?php endif; ?>
 </section>

--- a/src/views/news-block/index.php
+++ b/src/views/news-block/index.php
@@ -38,17 +38,17 @@ if ( empty( $items ) ) {
 	<?php if ( ! empty( $c->get_title() ) || ! empty( $c->get_description() ) ) : ?>
 		<div class="ucsc-news-block__header<?php echo esc_attr( $c->get_alignment() ); ?>">
 			<?php if ( ! empty( $c->get_title() ) ) : ?>
-				<h2 class="ucsc-news-block__header-title"><?php echo $c->get_title(); ?></h2>
+				<h2 class="ucsc-news-block__header-title"><?php echo esc_html( $c->get_title() ); ?></h2>
 			<?php endif; ?>
 
 			<?php if ( ! empty( $c->get_description() ) ) : ?>
-				<div class="ucsc-news-block__header-description"><?php echo $c->get_description(); ?></div>
+				<div class="ucsc-news-block__header-description"><?php echo wp_kses_post( $c->get_description() ); ?></div>
 			<?php endif; ?>
 		</div>
 	<?php endif; ?>
 
 	<?php if ( count( $items ) < 1 ) { ?>
-		<p><?php echo _e( 'No articles found', 'ucsc' ); ?></p>
+		<p><?php esc_html_e( 'No articles found', 'ucsc' ); ?></p>
 	<?php } else { ?>
 		<div class="ucsc-news-block__cards-wrapper">
 		<?php foreach ( $items as $item ) : ?>
@@ -76,7 +76,7 @@ if ( empty( $items ) ) {
 	
 				<?php if ( ! empty( $item['excerpt'] ) ) : ?>
 					<div class="ucsc-news-block__card-excerpt">
-						<?php echo $item['excerpt']; ?>
+						<?php echo wp_kses_post( $item['excerpt'] ); ?>
 					</div>
 				<?php endif; ?>
 
@@ -94,7 +94,7 @@ if ( empty( $items ) ) {
 			
 						<?php if ( ! empty( $item['authors'] ) ) : ?>
 							<span class="ucsc-news-block__card-authors">
-								<?php echo count( $item['authors'] ) > 1 ? esc_html__( 'By', 'ucsc' ) . ' ' . implode( ' and ', $item['authors'] ) : reset( $item['authors'] ); ?>
+								<?php echo count( $item['authors'] ) > 1 ? esc_html__( 'By', 'ucsc' ) . ' ' . esc_html( implode( ' and ', $item['authors'] ) ) : esc_html( reset( $item['authors'] ) ); ?>
 							</span>
 						<?php endif; ?>
 	

--- a/src/views/photo-of-the-week-block/index.php
+++ b/src/views/photo-of-the-week-block/index.php
@@ -38,20 +38,20 @@ if ( empty( $photo ) ) {
 }
 
 ?>
-<section <?php echo $c->get_attributes(); ?>>
+<section <?php echo $c->get_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Abstract_Controller::get_attributes(). ?>>
 	<figure class="ucsc-photo-of-the-week-block__inner">
-		<a class="ucsc-photo-of-the-week-block__image-link" href="<?php echo $photo['download']; ?>" target="_blank">
-			<?php echo $photo['image']; ?>
+		<a class="ucsc-photo-of-the-week-block__image-link" href="<?php echo esc_url( $photo['download'] ); ?>" target="_blank">
+			<?php echo $photo['image']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped markup built by Photo_Of_The_Week_Block_Controller::get_photo(). ?>
 		</a>
 		<figcaption>
 			<div class="ucsc-photo-of-the-week-block__caption">
 				<h2 class="ucsc-photo-of-the-week-block__title has-six-font-size">
-					<?php echo $c->get_title(); ?>
+					<?php echo esc_html( $c->get_title() ); ?>
 				</h2>
 				<hr />
 				<p>
 					<span class="ucsc-photo-of-the-week-block__post-title has-three-font-size">
-						<?php echo $photo['title']; ?>
+						<?php echo esc_html( $photo['title'] ); ?>
 					</span>
 					<?php if ( strlen( $photo['author'] ) > 1 ) : ?>
 					<span class="ucsc-photo-of-the-week-block__post-author">
@@ -59,12 +59,12 @@ if ( empty( $photo ) ) {
 							<path d="M2.5.5h4M9.5 12.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/>
 							<path d="M14.5 15.5h-13a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1h13a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1Z"/>
 						</svg>
-						<?php echo esc_html__( 'By ', 'ucsc' ) . $photo['author']; ?>
+						<?php echo esc_html__( 'By ', 'ucsc' ) . esc_html( $photo['author'] ); ?>
 					</span>
 					<?php endif; ?>
 				</p>
 				<hr />
-				<a class="ucsc-photo-of-the-week-block__download-link has-ucsc-pacific-blue-color" href="<?php echo $photo['download']; ?>" target="_blank">
+				<a class="ucsc-photo-of-the-week-block__download-link has-ucsc-pacific-blue-color" href="<?php echo esc_url( $photo['download'] ); ?>" target="_blank">
 					<svg width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
 						<path d="M8 .5v11M3.5 7 8 11.5 12.5 7M.5 15.5h15" />
 					</svg>
@@ -72,11 +72,11 @@ if ( empty( $photo ) ) {
 				</a>
 			</div>
 			<div class="ucsc-photo-of-the-week-block__cta ucsc-photo-of-the-week-block__cta--desktop is-style-ucsc-outline-white">
-				<?php echo $c->get_cta( [ 'wp-element-button' ] ); ?>
+				<?php echo $c->get_cta( [ 'wp-element-button' ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by With_CTA::get_cta(). ?>
 			</div>
 		</figcaption>
 	</figure>
 	<div class="ucsc-photo-of-the-week-block__cta ucsc-photo-of-the-week-block__cta--mobile is-style-ucsc-outline-white">
-		<?php echo $c->get_cta( [ 'wp-element-button' ] ); ?>
+		<?php echo $c->get_cta( [ 'wp-element-button' ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by With_CTA::get_cta(). ?>
 	</div>
 </section>

--- a/src/views/photos-week-loop/index.php
+++ b/src/views/photos-week-loop/index.php
@@ -25,12 +25,12 @@ $image = $c->get_image();
 		<?php if ( $posts->have_posts() ) : ?>
 			<?php while ( $posts->have_posts() ) : ?>
 				<?php $posts->the_post(); ?>
-			<figure class="wp-block-post post-<?php echo get_the_ID(); ?> photo-of-the-week type-photo_of_the_week status-publish hentry">
-				<?php echo $c->render_image(); ?>
+			<figure class="wp-block-post post-<?php echo esc_attr( (string) get_the_ID() ); ?> photo-of-the-week type-photo_of_the_week status-publish hentry">
+				<?php echo $c->render_image(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped markup built by Photo_Of_The_Week_Archive_Controller::render_image(). ?>
 				<figcaption>
 					<div class="photo-of-the-week__caption">
 						<h2 class="photo-of-the-week__title has-ucsc-primary-blue-color has-two-font-size">
-							<?php echo get_the_title(); ?>
+							<?php echo esc_html( get_the_title() ); ?>
 						</h2>
 						<?php $author = get_field( Photo_Of_The_Week_Meta::PHOTOGRAPHER, get_the_ID() ); ?>
 						<?php if ( ! empty( $author ) ) : ?>
@@ -39,11 +39,11 @@ $image = $c->get_image();
 								<path d="M2.5.5h4M9.5 12.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/>
 								<path d="M14.5 15.5h-13a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1h13a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1Z"/>
 							</svg>
-							<?php echo $author; ?>
+							<?php echo esc_html( $author ); ?>
 						</p>
 						<?php endif; ?>
 					</div>
-					<a class="photo-of-the-week__download-link" href="<?php echo $image['url'] ?? '#'; ?>" target="_blank">
+					<a class="photo-of-the-week__download-link" href="<?php echo esc_url( $image['url'] ?? '#' ); ?>" target="_blank">
 						<svg width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
 							<path d="M8 .5v11M3.5 7 8 11.5 12.5 7M.5 15.5h15" />
 						</svg>
@@ -61,7 +61,7 @@ $image = $c->get_image();
 					</span>
 				<?php endif; ?>
 				
-				<?php echo $c->get_pagination( $posts, $paged ); ?>
+				<?php echo $c->get_pagination( $posts, $paged ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- markup from paginate_links(). ?>
 
 				<?php if ( $paged === $posts->max_num_pages ) : ?>
 					<span class="page-numbers next">

--- a/src/views/post-header-block/index.php
+++ b/src/views/post-header-block/index.php
@@ -24,10 +24,10 @@ $primary_term = $c->get_primary_category();
 $image        = $c->get_image();
 ?>
 
-<section <?php echo $c->get_attributes(); ?>>
+<section <?php echo $c->get_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Abstract_Controller::get_attributes(). ?>>
 	<div class="ucsc-post-header-block__container alignfull is-layout-constrained has-global-padding has-ucsc-primary-blue-background-color has-white-color">
 		<nav class="ucsc-post-header-block__breadcrumb">
-			<a href="<?php echo get_bloginfo( 'url' ); ?>">
+			<a href="<?php echo esc_url( get_bloginfo( 'url' ) ); ?>">
 				<svg xmlns="http://www.w3.org/2000/svg" width="12" height="13" viewBox="0 0 12 13" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round">
 					<path d="M6 0.875L1.125 6.125V12.125H4.875V9.125H7.125V12.125H10.875V6.125L6 0.875Z" />
 				</svg>
@@ -49,27 +49,27 @@ $image        = $c->get_image();
 			<hgroup>
 				<?php if ( ! empty( $primary_term ) ) : ?>
 					<p class="ucsc-post-header-block__eyebrow has-one-font-size has-ucsc-primary-yellow-color">
-						<?php echo $primary_term; ?>
+						<?php echo esc_html( $primary_term ); ?>
 					</p>
 				<?php endif; ?>
 				<h1 class="ucsc-post-header-block__title has-seven-font-size">
-					<?php echo get_the_title( get_the_ID() ); ?>
+					<?php echo esc_html( get_the_title( get_the_ID() ) ); ?>
 				</h1>
 			</hgroup>
 
 			<div class="ucsc-post-header-block__excerpt has-one-font-size">
 				<p>
-					<?php echo get_the_excerpt( get_the_ID() ); ?>
+					<?php echo wp_kses_post( get_the_excerpt( get_the_ID() ) ); ?>
 				</p>
 			</div>
 
 			<div class="ucsc-post-header-block__meta">
-				<time datetime="<?php echo get_the_date( 'Y-m-d', get_the_ID() ); ?>">
-					<?php echo get_the_date( 'F j, Y', get_the_ID() ); ?>
+				<time datetime="<?php echo esc_attr( get_the_date( 'Y-m-d', get_the_ID() ) ); ?>">
+					<?php echo esc_html( get_the_date( 'F j, Y', get_the_ID() ) ); ?>
 				</time>
 				<span role="separator"></span>
 				<p class="ucsc-post-header-block__authors">
-					<?php echo do_blocks( '<!-- wp:post-author-name /-->' ); ?>
+					<?php echo do_blocks( '<!-- wp:post-author-name /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core block output. ?>
 				</p>
 			</div>
 		</header>
@@ -79,7 +79,7 @@ $image        = $c->get_image();
 			<div class="ucsc-post-header-block__image-container">
 				<div class="alignfull is-layout-constrained has-global-padding">
 					<div>
-						<?php echo $image['image']; ?>
+						<?php echo $image['image']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- markup from get_the_post_thumbnail(). ?>
 					</div>
 				</div>
 			</div>

--- a/src/views/press-inquiries/index.php
+++ b/src/views/press-inquiries/index.php
@@ -38,14 +38,14 @@ if ( $is_empty ) {
 	return;
 }
 ?>
-<section <?php echo $c->get_attributes(); ?>>
+<section <?php echo $c->get_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Abstract_Controller::get_attributes(). ?>>
 	<div class="ucsc-press-inquiries-block__container">
 		<div>
-			<button class="ucsc-press-inquiries-block__toggle" type="button" aria-expanded="false" aria-controls="<?php echo $c->get_panel_id(); ?>">
+			<button class="ucsc-press-inquiries-block__toggle" type="button" aria-expanded="false" aria-controls="<?php echo $c->get_panel_id(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Press_Inquiries_Controller::get_panel_id(). ?>">
 				<?php echo esc_html__( 'Press Inquiries', 'ucsc' ); ?>
 			</button>
 		</div>
-		<div class="ucsc-press-inquiries-block__inner-wrapper" id="<?php echo $c->get_panel_id(); ?>" inert>
+		<div class="ucsc-press-inquiries-block__inner-wrapper" id="<?php echo $c->get_panel_id(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Press_Inquiries_Controller::get_panel_id(). ?>" inert>
 			<div class="ucsc-press-inquiries-block__inner">
 				<div class="ucsc-press-inquiries-block__content">
 
@@ -58,22 +58,22 @@ if ( $is_empty ) {
 									<?php continue; ?>
 								<?php endif; ?>
 							<div class="ucsc-press-inquiries-block__contact" >
-								<h3><?php echo $contact[ Press_Inquiries_Block::PRESS_NAME ]; ?></h3>
+								<h3><?php echo esc_html( $contact[ Press_Inquiries_Block::PRESS_NAME ] ); ?></h3>
 								<p class="ucsc-press-inquiries-block__link-wrapper">
 									<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
 										<path d="M14 14.5H2C1.172 14.5 0.5 13.828 0.5 13V3C0.5 2.172 1.172 1.5 2 1.5H14C14.828 1.5 15.5 2.172 15.5 3V13C15.5 13.828 14.828 14.5 14 14.5Z" />
 										<path d="M2.5 4.5L8 9L13.5 4.5" />
 									</svg>
-									<a href="mailto:<?php echo $contact[ Press_Inquiries_Block::PRESS_EMAIL ]; ?>">
-										<?php echo $contact[ Press_Inquiries_Block::PRESS_EMAIL ]; ?>
+									<a href="<?php echo esc_url( 'mailto:' . $contact[ Press_Inquiries_Block::PRESS_EMAIL ] ); ?>">
+										<?php echo esc_html( $contact[ Press_Inquiries_Block::PRESS_EMAIL ] ); ?>
 									</a>
 								</p>
 								<p class="ucsc-press-inquiries-block__link-wrapper">
 									<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
 										<path d="M10.5137 9.76347L9.29171 11.2915C7.39815 10.1789 5.82025 8.60103 4.70771 6.70747L6.23571 5.48547C6.41483 5.34213 6.54142 5.14349 6.5957 4.9206C6.64997 4.6977 6.62888 4.46311 6.53571 4.25347L5.14271 1.11647C5.04282 0.891671 4.86633 0.709661 4.64472 0.602884C4.42311 0.496108 4.17078 0.471507 3.93271 0.533467L1.28071 1.22047C1.03335 1.28532 0.81832 1.43855 0.676258 1.65118C0.534197 1.86381 0.474949 2.12112 0.509714 2.37447C0.975006 5.68821 2.50649 8.76038 4.87265 11.1265C7.2388 13.4927 10.311 15.0242 13.6247 15.4895C13.878 15.5244 14.1352 15.4652 14.3478 15.3231C14.5603 15.181 14.7133 14.9659 14.7777 14.7185L15.4657 12.0675C15.5277 11.8294 15.5031 11.5771 15.3963 11.3555C15.2895 11.1339 15.1075 10.9574 14.8827 10.8575L11.7457 9.46447C11.5361 9.37154 11.3017 9.35047 11.0789 9.40454C10.8561 9.45862 10.6574 9.5848 10.5137 9.76347Z" />
 									</svg>
-									<a href="tel:<?php echo $contact[ Press_Inquiries_Block::PRESS_PHONE ]; ?>">
-										<?php echo $contact[ Press_Inquiries_Block::PRESS_PHONE ]; ?>
+									<a href="<?php echo esc_url( 'tel:' . $contact[ Press_Inquiries_Block::PRESS_PHONE ] ); ?>">
+										<?php echo esc_html( $contact[ Press_Inquiries_Block::PRESS_PHONE ] ); ?>
 									</a>
 								</p>
 							</div>
@@ -93,7 +93,7 @@ if ( $is_empty ) {
 								<path d="M9.5 0.5V5.5H14.5" />
 								<path d="M9.5 0.5H1.5V15.5H14.5V5.5L9.5 0.5Z" />
 							</svg>
-							<a href="<?php echo $media_file; ?>" target="_blank">
+							<a href="<?php echo esc_url( $media_file ); ?>" target="_blank">
 								<?php echo esc_html__( 'Access Paper', 'ucsc' ); ?>
 							</a>
 						</p>
@@ -106,14 +106,14 @@ if ( $is_empty ) {
 									<path d="M14 15.5H2C1.60218 15.5 1.22064 15.342 0.93934 15.0607C0.658035 14.7794 0.5 14.3978 0.5 14V2C0.5 1.60218 0.658035 1.22064 0.93934 0.93934C1.22064 0.658035 1.60218 0.5 2 0.5H14C14.3978 0.5 14.7794 0.658035 15.0607 0.93934C15.342 1.22064 15.5 1.60218 15.5 2V14C15.5 14.3978 15.342 14.7794 15.0607 15.0607C14.7794 15.342 14.3978 15.5 14 15.5Z" />
 									<path d="M5 6.5C5.82843 6.5 6.5 5.82843 6.5 5C6.5 4.17157 5.82843 3.5 5 3.5C4.17157 3.5 3.5 4.17157 3.5 5C3.5 5.82843 4.17157 6.5 5 6.5Z" />
 								</svg>
-								<a href="<?php echo $media_image; ?>" target="_blank">
+								<a href="<?php echo esc_url( $media_image ); ?>" target="_blank">
 									<?php echo esc_html__( 'Image Download', 'ucsc' ); ?>
 								</a>
 							</p>
 						<?php endif; ?>
 
 						<?php if ( ! empty( $media_text ) ) : ?>
-							<?php echo $media_text; ?>
+							<?php echo wp_kses_post( $media_text ); ?>
 						<?php endif; ?>
 					</div>
 					<?php endif; ?>

--- a/src/views/related-stories-block/index.php
+++ b/src/views/related-stories-block/index.php
@@ -40,7 +40,7 @@ if ( empty( $items ) ) {
 }
 
 ?>
-<aside <?php echo $c->get_attributes(); ?>>
+<aside <?php echo $c->get_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by Abstract_Controller::get_attributes(). ?>>
 	<h2 class="ucsc-related-stories-block__title has-ucsc-primary-blue-color has-five-font-size">
 		<?php echo esc_html__( 'Related Stories', 'ucsc' ); ?>
 	</h2>
@@ -53,9 +53,9 @@ if ( empty( $items ) ) {
 					<?php $image_alt = get_post_meta( $item['image']['id'], '_wp_attachment_image_alt', true ); ?>
 					<img 
 						src="<?php echo esc_url( $item['image']['url'] ); ?>" 
-						srcset="<?php echo $c->build_srcset( $item['image'] ); ?>" 
+						srcset="<?php echo esc_attr( $c->build_srcset( $item['image'] ) ); ?>" 
 						class="ucsc-related-stories-block__featured-image"
-						alt="<?php echo ! empty( $image_alt ) ? esc_attr( get_post_meta( $item['image']['id'], '_wp_attachment_image_alt' )[0] ) : $item['title']; ?>"
+						alt="<?php echo esc_attr( ! empty( $image_alt ) ? $image_alt : $item['title'] ); ?>"
 					/>
 				</div>
 				<?php endif; ?>
@@ -63,7 +63,7 @@ if ( empty( $items ) ) {
 				<hgroup>
 					<?php if ( ! empty( $item['category'] ) ) : ?>
 					<p class="ucsc-related-stories-block__card-category">
-						<?php echo $item['category']->name; ?>
+						<?php echo esc_html( $item['category']->name ); ?>
 					</p>
 					<?php endif; ?>
 


### PR DESCRIPTION
## What does this do/fix?

Step 4 of #116 — the security slice. Clears every `WordPress.Security.EscapeOutput` finding.

**phpcs: 153 errors → 71.** 13 files, 80 findings.

All 80 were in the block view templates. They were **not** all false positives — most were genuinely unescaped output.

## 1. Real unescaped output

Values reaching the browser with no escaping at all. Several are not authored on this site:

| view | what was unescaped |
|---|---|
| **news-block** | **post excerpts fetched over REST from `news.ucsc.edu`, rendered as raw HTML** |
| news-block | remote author names |
| media-coverage | `source_url` written straight into an `href` |
| press-inquiries | contact email and phone into `mailto:`/`tel:` hrefs; WYSIWYG brief as raw HTML |
| magazine | item titles, bylines, descriptions, tab keys |
| post-header | title, excerpt, primary term, dates |
| various | category names, titles, `srcset` attributes |

The news-block excerpt is the one that matters most: it is the only output in the plugin whose source is **another host**. Everything else is authored by editors on this site; that content still needs escaping, but it sits behind an authentication boundary. Remote HTML does not.

Text output now goes through `esc_html()`, attributes through `esc_attr()`, URLs through `esc_url()`, and the three fields that are meant to carry markup — the two excerpts and the WYSIWYG brief — through `wp_kses_post()` rather than being stripped.

## 2. Escaped on one branch, not the other

Two card views escaped the attachment's alt text but fell back to an **unescaped post title**:

```diff
- alt="<?php echo ! empty( $image_alt ) ? esc_attr( get_post_meta( $item['image']['id'], '_wp_attachment_image_alt' )[0] ) : $item['title']; ?>"
+ alt="<?php echo esc_attr( ! empty( $image_alt ) ? $image_alt : $item['title'] ); ?>"
```

Worth reading closely: the original called `get_post_meta()` twice — once with `true` into `$image_alt` to test it, then again *without* `true` and took `[0]` to print it. For single-valued meta those are the same string, so the rewrite is equivalent and drops one database call per image.

## 3. Escaping moved to the source

Four helpers assemble HTML that views echo whole. Escaping belongs where the markup is built, not at each call site:

- `With_CTA::get_cta()` — url, target and title all came straight from the ACF link field
- `Magazine_Block_Controller::get_image()` — src, srcset, alt
- `Photo_Of_The_Week_Block_Controller::get_photo()`
- `Photo_Of_The_Week_Archive_Controller::render_image()`

Their call sites carry a scoped `phpcs:ignore` naming the method responsible, as does output from `get_block_wrapper_attributes()`, `get_the_post_thumbnail()`, `do_blocks()` and `paginate_links()`. Every ignore names *why*; none are blanket suppressions.

## ⚠️ A double-escaping bug, found while fixing the above

`Magazine_Block_Controller::get_cta()` was already escaping its return values, and the view now escaped them again:

```
raw:            Arts & Sciences
escaped once:   Arts &amp; Sciences
escaped twice:  Arts &amp;amp; Sciences   → renders as "Arts &amp; Sciences"
```

The controller now returns raw data and the view escapes it — matching every other controller, and the reason the mixed convention was a trap in the first place. It has exactly one caller, confirmed by grep.

Also replaces `echo _e( 'No articles found' )` with `esc_html_e()`, which resolves the redundant-echo item tracked in #106.

## Tests

```bash
composer lint    # 71 errors, down from 153
npm run build    # green
```

Verified locally:

- [x] All 13 changed files pass `php -l`
- [x] **Zero `EscapeOutput` findings remain**
- [x] No double-escaping: every controller that still escapes internally builds markup and is annotated at its call site
- [x] `npm run build` green

Two notes on what I could **not** verify locally, since there is no WordPress runtime here:

- `tel:` and `mailto:` are both in WordPress's `wp_allowed_protocols()`, so `esc_url()` preserves them. I am relying on the documented protocol list rather than having executed it. A phone number containing spaces will be emitted as `%20`, which browsers accept for `tel:`.
- `wp_kses_post()` on the three markup-bearing fields will strip tags outside the post allow-list. For the remote news excerpt and the WYSIWYG brief that is the intent, but it is a behaviour change worth a visual check.

Reviewer checks — these want a real install:

- [ ] News block renders excerpts with formatting intact (not stripped, not double-encoded)
- [ ] Press Inquiries email and phone links still dial/compose correctly
- [ ] Magazine CTA with an ampersand in the title renders as `&` — this is the double-escape fix
- [ ] Media Coverage outbound links still work and still get `target="_blank"`
- [ ] Photo of the Week image and download link render
- [ ] Post header, related stories and featured news cards render with images and alt text

## What remains on #116

| step | scope | count |
|---|---|---|
| ~~1–4~~ | ~~mechanical, docblocks, escaping~~ | ✅ |
| 5 | long tail — Yoda conditions, short ternaries, misc | 71 |
| — | eslint `no-unused-vars` + missing JSDoc return | 2 |
