### PR TITLE
chore: clear the long tail of lint findings (completes #116)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -77,6 +77,23 @@
 		<exclude-pattern>/src/*</exclude-pattern>
 	</rule>
 
+	<!--
+	The block view templates in src/views/ are included from inside
+	Core::render_template(), so the variables they declare are method-local,
+	not global. phpcs analyses each file standalone and cannot see that, so it
+	reports every view variable as an unprefixed global and flags names like
+	$posts and $title as overriding WordPress globals. Neither is true here.
+
+	Both sniffs stay fully enforced everywhere else, including the rest of src/.
+	-->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/src/views/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>/src/views/*</exclude-pattern>
+	</rule>
+
 	<!-- Let's also check that everything is properly documented. -->
 	<rule ref="WordPress-Docs"/>
 

--- a/lib/functions/admin-menus.php
+++ b/lib/functions/admin-menus.php
@@ -65,7 +65,7 @@ if ( ! function_exists( 'ucsc_custom_functionality_remove_from_dash_panel' ) ) {
 	function ucsc_custom_functionality_remove_from_dash_panel() {
 		global $submenu;
 		foreach ( $submenu as $name => $items ) {
-			if ( $name === 'themes.php' ) {
+			if ( 'themes.php' === $name ) {
 				foreach ( $items as $i => $data ) {
 					if ( in_array( 'customize', $data, true ) ) {
 						unset( $submenu[ $name ][ $i ] );

--- a/lib/functions/shortcodes.php
+++ b/lib/functions/shortcodes.php
@@ -21,7 +21,7 @@ if ( ! function_exists( 'ucsc_custom_functionality_google_search' ) ) {
 
 		// Configuration params to be added to the output string.
 		$script_source = 'https://cse.google.com/cse.js?cx=012090462228956765947:d0ywvq7bxee';
-		$site_url      = parse_url( get_site_url(), PHP_URL_HOST );
+		$site_url      = wp_parse_url( get_site_url(), PHP_URL_HOST );
 
 		// phpcs:disable WordPress.WP.CapitalPDangit -- lowercase hostname fragments matched case-sensitively, not the product name.
 		/**
@@ -37,6 +37,7 @@ if ( ! function_exists( 'ucsc_custom_functionality_google_search' ) ) {
 		// phpcs:enable WordPress.WP.CapitalPDangit
 
 		// Return the configured string for Google Search results to display on the page.
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Google's CSE embed must load inline at the shortcode's position.
 		return sprintf( '<script async src="%s"></script><div class="gcse-searchresults-only" data-queryParameterName="s" data-as_sitesearch="%s"></div>', $script_source, $search_url );
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,10 @@ declare(strict_types=1);
 define( 'UCSC_DIR', __DIR__ );
 define( 'UCSC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
+// Read the version from this file's own header, so it always matches the
+// value the release tooling bumps and cannot drift out of sync.
+define( 'UCSC_VERSION', get_file_data( __FILE__, array( 'Version' => 'Version' ) )['Version'] );
+
 // Include Customization files.
 
 if ( file_exists( UCSC_DIR . '/vendor/autoload.php' ) ) {
@@ -63,7 +67,7 @@ if ( ! function_exists( 'ucsc_enqueue_admin_styles' ) ) {
 	 * @param string $hook The current admin page hook suffix. Unused; the screen
 	 *                     is resolved through get_current_screen() instead.
 	 */
-	function ucsc_enqueue_admin_styles( $hook ): void {
+	function ucsc_enqueue_admin_styles( $hook ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- signature fixed by the admin_enqueue_scripts contract.
 		$settings_css   = plugin_dir_url( __FILE__ ) . 'lib/css/admin-settings.css';
 		$current_screen = get_current_screen();
 		// Check if it's "?page=ucsc-custom-functionality-settings." If not, just empty return.
@@ -72,7 +76,7 @@ if ( ! function_exists( 'ucsc_enqueue_admin_styles' ) ) {
 		}
 
 		// Load css.
-		wp_register_style( 'ucsc-cf-admin-settings', $settings_css, );
+		wp_register_style( 'ucsc-cf-admin-settings', $settings_css, array(), UCSC_VERSION );
 		wp_enqueue_style( 'ucsc-cf-admin-settings' );
 	}
 }

--- a/src/Blocks/Query_Loop.php
+++ b/src/Blocks/Query_Loop.php
@@ -213,7 +213,7 @@ abstract class Query_Loop extends ACF_Group implements Taxonomies {
 		return [
 			'key'               => $this->get_field_key( self::AUTOMATIC_GROUP, $this->block_name ),
 			'type'              => 'group',
-			'label'             => esc_html__( '', 'ucsc' ),
+			'label'             => '',
 			'name'              => self::QUERY_LOOP,
 			'sub_fields'        => [
 				$this->get_taxonomies_list( $this->block_name ),

--- a/src/Blocks/Traits/With_CTA_Field.php
+++ b/src/Blocks/Traits/With_CTA_Field.php
@@ -29,7 +29,7 @@ trait With_CTA_Field {
 		return [
 			'label' => $label,
 			'type'  => 'link',
-			'name'  => $name ?: self::CTA,
+			'name'  => ! empty( $name ) ? $name : self::CTA,
 			'key'   => $this->get_field_key( $name, $group_name ),
 		];
 	}

--- a/src/Components/Featured_News_Block_Controller.php
+++ b/src/Components/Featured_News_Block_Controller.php
@@ -41,7 +41,8 @@ class Featured_News_Block_Controller extends Query_Loop_Controller {
 	public function __construct( $block ) {
 		parent::__construct( $block );
 
-		$this->cta = (array) get_field( Featured_News_Block::CTA_FIELD ) ?: [];
+		$cta_field = get_field( Featured_News_Block::CTA_FIELD );
+		$this->cta = is_array( $cta_field ) ? $cta_field : [];
 	}
 
 	/**
@@ -66,7 +67,8 @@ class Featured_News_Block_Controller extends Query_Loop_Controller {
 			$image_meta = $image_id > 0 ? wp_get_attachment_metadata( $image_id ) : [];
 			$image_meta = is_array( $image_meta ) ? $image_meta : [];
 			$image_url  = wp_get_attachment_url( $image_id );
-			$taxonomy   = $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ] ?: 'category';
+			$selected   = $this->query_loop[ Query_Loop::QUERY_LOOP ][ Taxonomies::TAXONOMIES ] ?? '';
+			$taxonomy   = ! empty( $selected ) ? $selected : 'category';
 			$category   = $this->get_primary_term( $post_id, $taxonomy );
 			$args       = [
 				'id'       => $post_id,
@@ -82,7 +84,7 @@ class Featured_News_Block_Controller extends Query_Loop_Controller {
 			];
 
 			// Large card.
-			if ( $key === 0 ) {
+			if ( 0 === $key ) {
 				$args['excerpt'] = get_the_excerpt( $post_id );
 			}
 

--- a/src/Components/Media_Coverage_Controller.php
+++ b/src/Components/Media_Coverage_Controller.php
@@ -46,7 +46,8 @@ class Media_Coverage_Controller extends Query_Loop_Controller {
 	public function __construct( $block ) {
 		parent::__construct( $block );
 
-		$this->cta = (array) get_field( Media_Coverage_Block::CTA_FIELD ) ?: [];
+		$cta_field = get_field( Media_Coverage_Block::CTA_FIELD );
+		$this->cta = is_array( $cta_field ) ? $cta_field : [];
 	}
 
 	/**

--- a/src/Components/News_Block_Controller.php
+++ b/src/Components/News_Block_Controller.php
@@ -192,7 +192,7 @@ class News_Block_Controller {
 	 * @return string
 	 */
 	public function get_alignment(): string {
-		return $this->layout !== News_Block::LAYOUT_CENTRE ? ' align-header-left' : '';
+		return News_Block::LAYOUT_CENTRE !== $this->layout ? ' align-header-left' : '';
 	}
 
 	/**

--- a/src/Components/Photo_Of_The_Week_Block_Controller.php
+++ b/src/Components/Photo_Of_The_Week_Block_Controller.php
@@ -100,6 +100,7 @@ class Photo_Of_The_Week_Block_Controller {
 			return null;
 		}
 
+		$image      = '';
 		$image_data = $this->get_photo_image( $photo );
 
 		if ( ! empty( $image_data ) ) {
@@ -113,8 +114,8 @@ class Photo_Of_The_Week_Block_Controller {
 
 		return [
 			'id'       => $photo,
-			'image'    => $image ?: '',
-			'download' => $image_data['url'] ?: '',
+			'image'    => $image,
+			'download' => $image_data['url'] ?? '',
 			'title'    => get_the_title( $photo ),
 			'author'   => $this->get_photo_author( $photo ),
 		];

--- a/src/Components/Query_Loop_Controller.php
+++ b/src/Components/Query_Loop_Controller.php
@@ -97,11 +97,11 @@ abstract class Query_Loop_Controller {
 	public function get_items(): array {
 		$query_type = $this->query_loop[ Query_Loop::QUERY_TYPE ] ?? Query_Loop::LATEST;
 
-		if ( empty( $query_type ) || $query_type === Query_Loop::LATEST ) {
+		if ( empty( $query_type ) || Query_Loop::LATEST === $query_type ) {
 			return $this->get_latest_query_items();
 		}
 
-		if ( $query_type === Query_Loop::AUTOMATIC ) {
+		if ( Query_Loop::AUTOMATIC === $query_type ) {
 			return $this->get_automatic_query_items();
 		}
 

--- a/src/Components/Related_Stories_Block_Controller.php
+++ b/src/Components/Related_Stories_Block_Controller.php
@@ -88,7 +88,7 @@ class Related_Stories_Block_Controller extends Query_Loop_Controller {
 						'id'  => $image_id,
 						'url' => $image_url,
 					],
-					$image_meta !== false ? $image_meta : []
+					false !== $image_meta ? $image_meta : []
 				),
 				'category' => $category,
 			];

--- a/src/Core.php
+++ b/src/Core.php
@@ -118,6 +118,7 @@ class Core {
 		$this->templates();
 	}
 
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter -- signature fixed by the block render_callback contract.
 	/**
 	 * Render an ACF block by including its view template.
 	 *
@@ -144,6 +145,7 @@ class Core {
 
 		include "$path/$template"; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 	}
+	// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter
 
 	/**
 	 * Inject the custom block templates on news sites.
@@ -268,7 +270,7 @@ class Core {
 					'ucsc-news-block-scripts',
 					UCSC_PLUGIN_URL . '/assets/js/news-block.js',
 					[],
-					false,
+					UCSC_VERSION,
 					true
 				);
 				wp_enqueue_script( 'ucsc-news-block-scripts' );
@@ -281,7 +283,7 @@ class Core {
 					'ucsc-custom-block-scripts',
 					UCSC_PLUGIN_URL . '/assets/js/custom-blocks.js',
 					[],
-					false,
+					UCSC_VERSION,
 					true
 				);
 				wp_enqueue_script( 'ucsc-custom-block-scripts' );

--- a/src/Hooks/News_Blocks_Hooks.php
+++ b/src/Hooks/News_Blocks_Hooks.php
@@ -77,7 +77,7 @@ class News_Blocks_Hooks {
 
 		$choices = [];
 		foreach ( $response as $taxonomy_name => $value ) {
-			if ( ! isset( $value['rest_base'] ) || ! in_array( $taxonomy_name, News_Block::ALLOWED_TAX ) ) {
+			if ( ! isset( $value['rest_base'] ) || ! in_array( $taxonomy_name, News_Block::ALLOWED_TAX, true ) ) {
 				continue;
 			}
 

--- a/src/Hooks/Taxonomies_Hooks.php
+++ b/src/Hooks/Taxonomies_Hooks.php
@@ -83,7 +83,7 @@ class Taxonomies_Hooks {
 		 * @var \WP_Taxonomy[] $taxonomies
 		 */
 		foreach ( $taxonomies as $key => $taxonomy ) {
-			if ( in_array( $key, self::RESTRICTED_TAXONOMIES ) ) {
+			if ( in_array( $key, self::RESTRICTED_TAXONOMIES, true ) ) {
 				continue;
 			}
 

--- a/src/Template/Photo_Of_The_Week_Archive.php
+++ b/src/Template/Photo_Of_The_Week_Archive.php
@@ -69,6 +69,7 @@ class Photo_Of_The_Week_Archive extends Template {
 			'post_excerpt' => $post_excerpt,
 			'post_type'    => 'wp_template',
 			'post_status'  => 'publish',
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a template shipped inside this plugin, not a remote or user-supplied file.
 			'post_content' => file_get_contents( UCSC_DIR . '/src/views/templates/photo-of-the-week-archive.html' ),
 			'tax_input'    => [
 				'wp_theme' => $this->get_namespace(),

--- a/src/Template/Post_Single.php
+++ b/src/Template/Post_Single.php
@@ -53,7 +53,7 @@ class Post_Single extends Template {
 	public function register( $query_result, $query, $template_type ) {
 		$template = $this->register_template();
 
-		if ( empty( $template ) || ! is_single() || in_array( 'embed-post', $query['slug__in'] ) ) {
+		if ( empty( $template ) || ! is_single() || in_array( 'embed-post', $query['slug__in'], true ) ) {
 			return $query_result;
 		}
 
@@ -74,6 +74,7 @@ class Post_Single extends Template {
 			'post_excerpt' => $post_excerpt,
 			'post_type'    => 'wp_template',
 			'post_status'  => 'publish',
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a template shipped inside this plugin, not a remote or user-supplied file.
 			'post_content' => file_get_contents( UCSC_DIR . '/src/views/templates/post-single.html' ),
 			'tax_input'    => [
 				'wp_theme' => $this->get_namespace(),

--- a/src/views/featured-news-block/index.php
+++ b/src/views/featured-news-block/index.php
@@ -39,7 +39,7 @@ if ( empty( $items ) && is_admin() ) {
 <section <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<div class="ucsc-featured-news-block__inner">
 		<?php foreach ( $items as $key => $item ) : ?>
-			<a href="<?php echo esc_url( get_the_permalink( $item['id'] ) ); ?>" class="ucsc-featured-news-block__card<?php echo $key === 0 ? esc_attr( ' ucsc-featured-news-block__card--sticky' ) : ''; ?>">
+			<a href="<?php echo esc_url( get_the_permalink( $item['id'] ) ); ?>" class="ucsc-featured-news-block__card<?php echo 0 === $key ? esc_attr( ' ucsc-featured-news-block__card--sticky' ) : ''; ?>">
 				<?php if ( ! empty( $item['image'] ) && $item['image']['id'] > 0 ) : ?>
 					<div class="ucsc-featured-news-block__card-image">
 						<?php $image_alt = get_post_meta( $item['image']['id'], '_wp_attachment_image_alt', true ); ?>
@@ -63,7 +63,7 @@ if ( empty( $items ) && is_admin() ) {
 					</span>
 				</h2>
 	
-				<?php if ( $key === 0 && ! empty( $item['excerpt'] ) ) : ?>
+				<?php if ( 0 === $key && ! empty( $item['excerpt'] ) ) : ?>
 					<p class="ucsc-featured-news-block__card-excerpt"><?php echo wp_kses_post( $item['excerpt'] ); ?></p>
 				<?php endif; ?>
 			</a>

--- a/src/views/magazine-block/index.js
+++ b/src/views/magazine-block/index.js
@@ -22,7 +22,11 @@ const getBlockTabs = ( block ) => {
  *
  * @param {HTMLButtonElement} tab
  * @param {HTMLElement}       block
+ * @return {HTMLElement} The panel the tab controls.
  */
+// `block` is unused pending #127: the lookup should be scoped to it once tab
+// and panel ids are unique per block instance.
+// eslint-disable-next-line no-unused-vars
 const getTabPanel = ( tab, block ) => {
 	return document.getElementById( tab.getAttribute( 'aria-controls' ) );
 };
@@ -34,7 +38,7 @@ const getTabPanel = ( tab, block ) => {
  * @param {HTMLButtonElement}   fromTab
  * @param {HTMLButtonElement[]} tabs
  * @param {number}              offset
- * @return {HTMLButtonElement}
+ * @return {HTMLButtonElement} The tab at the offset position, wrapping around.
  */
 const getRelativeTab = ( fromTab, tabs, offset ) => {
 	const currentIndex = tabs.indexOf( fromTab );

--- a/src/views/photos-week-loop/index.php
+++ b/src/views/photos-week-loop/index.php
@@ -55,7 +55,7 @@ $image = $c->get_image();
 	
 			<!-- Pagination -->
 			<nav class="ucsc-pagination wp-block-query-pagination is-content-justification-center is-layout-flex wp-container-core-query-pagination-is-layout-1 wp-block-query-pagination-is-layout-flex">
-				<?php if ( $paged === 1 ) : ?>
+				<?php if ( 1 === $paged ) : ?>
 					<span class="page-numbers prev">
 						<?php echo esc_html__( 'Previous', 'ucsc' ); ?>
 					</span>


### PR DESCRIPTION
## What does this do/fix?

Step 5 of #116 — the final slice. Completes the backlog burn-down that began when #101 repaired the linters.

| linter | before this PR | after |
|---|---|---|
| phpcs | 71 errors / 12 warnings | **6 errors / 0 warnings** |
| eslint | 2 errors | **0** |
| stylelint | clean | clean |

`npm run lint` now exits **0**.

## The tail was not homogeneous style

It broke into four groups, and treating it as one pile of nitpicks would have missed real bugs.

### 1. False positives — 46 of 83, scoped off in the ruleset

The block view templates are included from **inside `Core::render_template()`**, so the variables they declare are method-local:

```php
include "$path/$template";   // inside a method, not at global scope
```

phpcs analyses each file standalone and cannot see that, so it reported every view variable as an unprefixed global, and flagged `$posts`, `$paged`, `$title` and `$tag` as overriding WordPress globals. Neither is true.

`PrefixAllGlobals` and `GlobalVariablesOverride` are now excluded **for `src/views/` only**, with the reason recorded in the ruleset. Both remain fully enforced everywhere else, including the rest of `src/` — verified with `phpcs -e`.

### 2. Latent bugs the style rules exposed

The short-ternary rule in particular was doing real work:

| expression | problem |
|---|---|
| `(array) get_field( … ) ?: []` | `get_field()` returns `false` when a field is absent, and **`(array) false` is `[ false ]`** — a truthy, non-empty array — so the fallback never applied. Two controllers now test `is_array()`. |
| `$image ?: ''` | `$image` was only assigned inside a preceding conditional, so the empty path read an **undefined variable**. |
| `$query_loop[…][…] ?: 'category'` | read a possibly-absent index, warning before falling back. |
| `in_array( … )` ×3 | non-strict comparison — including the News block's **remote-taxonomy allow-list**, now strict. |

### 3. Genuine improvements

- `parse_url()` → `wp_parse_url()`.
- **Explicit asset versions.** There was no version constant, and the release tooling (`wp-plugin-version-updater.js`) only rewrites `Version:` in the plugin header — so a hand-maintained constant would silently drift on every release. `UCSC_VERSION` is instead read from that header with `get_file_data()`, so it cannot fall out of sync.
- Drops `esc_html__( '', 'ucsc' )`, which returned the **PO file's metadata header** rather than an empty string. That resolves the last outstanding item tracked in #106.

### 4. Annotated with reasons, not fixed

Each carries a scoped ignore naming *why*:

- parameters required by the `render_callback` and `admin_enqueue_scripts` signatures
- reads of template HTML **shipped inside this plugin** (not remote, not user-supplied)
- Google's CSE embed, which must load inline at the shortcode's position

## ⚠️ Six findings deliberately left visible

All six remaining phpcs errors are `WordPress.Security.NonceVerification` in the two ACF AJAX handlers.

**I did not suppress them.** Silencing a security warning without addressing it is worse than the warning. They sit on the same lines as the missing input guards already tracked in **#103**, and whether a nonce check is even correct here needs a decision about ACF's own AJAX nonce — that is #103's call, not a lint pass's.

## One bug found, filed as #127

The remaining eslint `no-unused-vars` was a symptom, not noise. `getTabPanel()` takes a `block` argument and ignores it, resolving panels with global `document.getElementById` — while its sibling `getBlockTabs()` correctly scopes to the block. Combined with `make_tab_key()` composing ids from only the item title and index, **two Magazine blocks on one page sharing an item title emit duplicate ids**, and clicking a tab in one can open the panel in the other.

Filed as #127 with both halves of the fix. The parameter is annotated rather than deleted, so the evidence survives.

## Tests

```bash
composer lint   # 6 errors (all NonceVerification, see #103)
npm run lint    # exits 0
npm run build   # green
```

Verified locally:

- [x] All 19 changed files pass `php -l`
- [x] `npm run lint` exits 0 — eslint and stylelint both clean
- [x] `npm run build` green
- [x] Excluded sniffs confirmed still registered and active outside `src/views/` (`phpcs -e`)
- [x] The `(array) false` → `[ false ]` behaviour reproduced and confirmed fixed

Reviewer checks — this PR **does** change behaviour, unlike the docblock slices:

- [ ] Featured News and Media Coverage CTAs still render when set, and are absent when not (the `is_array()` change)
- [ ] Photo of the Week block renders when no image is attached (the undefined-`$image` path)
- [ ] Plugin assets load with `?ver=` matching the plugin version
- [ ] News block taxonomy dropdown still lists the expected taxonomies (strict `in_array` on the allow-list)
- [ ] Site search still detects dev hosts (`wp_parse_url` swap)

## #116 is complete after this

| step | scope | result |
|---|---|---|
| 1 | phpcbf mechanical | ✅ #118 — and caught a hostname-regex regression |
| 2 | eslint mechanical | ✅ #119 |
| 3 | docblocks | ✅ #120, #121, #124, #125 — 396 → 0 |
| 4 | `EscapeOutput` | ✅ #126 — 80 findings, incl. raw remote HTML |
| 5 | long tail | ✅ this PR |

**phpcs: 1345 errors / 31 warnings → 6 / 0. eslint: 135 → 0.**

Issues filed along the way: #122, #123, #127. Remaining 6 findings belong to #103.
