### PR TITLE
fix: give each block's script a unique handle

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Audit of `ucsc-custom-functionality` @ 2.0.6. Ordered by severity. Items marked 
 
 Every item is tracked by a GitHub issue in the **Issue** column. Several issues cover more than one item where the fixes belong in a single PR.
 
-**Status: 6 of 27 items resolved.** The **Status** column reflects the code on `main`, not whether the tracking issue is closed — an issue covering several items stays open until all of them land. Items found *after* the audit are listed under [Found since the audit](#found-since-the-audit).
+**Status: 7 of 27 items resolved.** The **Status** column reflects the code on `main`, not whether the tracking issue is closed — an issue covering several items stays open until all of them land. Items found *after* the audit are listed under [Found since the audit](#found-since-the-audit).
 
 ## P0 — Broken now
 
@@ -26,7 +26,7 @@ Every item is tracked by a GitHub issue in the **Issue** column. Several issues 
 | 9 | Unguarded index `$this->query_loop[ MANUAL_CARDS ]` in manual query mode. | [Query_Loop_Controller.php](src/Components/Query_Loop_Controller.php) | [#104](https://github.com/ucsc/ucsc-custom-functionality/issues/104) | Open |
 | 10 | **Yoast integration is a no-op loop.** Iterates `PRIMARY_TAX_SUPPORT` (5 taxonomies) but `$tax` is never used — only `academics` is ever registered. **verified** | [Integrations_Subscriber.php:17-26](src/Integrations/Integrations_Subscriber.php#L17-L26) | [#105](https://github.com/ucsc/ucsc-custom-functionality/issues/105) | Open |
 | 11 | `esc_html__( '', 'ucsc' )` — translating the empty string returns the PO file's metadata header, not `''`. **verified** | [Query_Loop.php:102](src/Blocks/Query_Loop.php#L102) | [#106](https://github.com/ucsc/ucsc-custom-functionality/issues/106) | ✅ Done |
-| 12 | **Duplicate script handle.** `Assets_Enqueuer` loops every registered UCSC block but enqueues each script under the same constant handle (`index`); only the first block's JS loads. Styles are correctly suffixed per block. **verified** | [Assets_Enqueuer.php](src/Assets/Assets_Enqueuer.php) | [#102](https://github.com/ucsc/ucsc-custom-functionality/issues/102) | Open |
+| 12 | **Duplicate script handle.** `Assets_Enqueuer` loops every registered UCSC block but enqueues each script under the same constant handle (`index`); only the first block's JS loads. Styles are correctly suffixed per block. **verified** | [Assets_Enqueuer.php](src/Assets/Assets_Enqueuer.php) | [#102](https://github.com/ucsc/ucsc-custom-functionality/issues/102) | ✅ Done |
 | 13 | `(int) get_field('posts_per_page') ?? self::PER_PAGE` — `??` is dead (a cast never yields null). Missing field → `0` → `array_slice(…, 0, 0)` → empty block. Affects blocks inserted before the field existed. | [News_Block_Controller.php:42](src/Components/News_Block_Controller.php#L42) | [#106](https://github.com/ucsc/ucsc-custom-functionality/issues/106) | Open |
 
 ## P2 — Performance & lifecycle

--- a/src/Assets/Assets_Enqueuer.php
+++ b/src/Assets/Assets_Enqueuer.php
@@ -50,14 +50,13 @@ class Assets_Enqueuer {
 	 *
 	 * Version and dependencies come from each block's generated asset file.
 	 *
-	 * Note: the style handle is suffixed per block, but the script handle is
-	 * not — every block enqueues its script under the same $handle_file, so
-	 * only the first one registered actually loads. Tracked in #102; left
-	 * as-is here so this stays a documentation-only change.
+	 * Both handles are suffixed with the block name: the built files all share
+	 * the same basename, so an unsuffixed handle would collide and WordPress
+	 * would silently drop every block after the first.
 	 *
 	 * @param string $assets_file Filename of the generated asset manifest, e.g. index.asset.php.
-	 * @param string $handle_file Script handle, also used as the .js basename.
-	 * @param string $css_handle  Stylesheet handle, also used as the .css basename.
+	 * @param string $handle_file Script handle prefix, also used as the .js basename.
+	 * @param string $css_handle  Stylesheet handle prefix, also used as the .css basename.
 	 *
 	 * @return void
 	 */
@@ -88,7 +87,7 @@ class Assets_Enqueuer {
 			);
 
 			wp_enqueue_script(
-				$handle_file,
+				$handle_file . '-' . $block_name,
 				$this->assets_path_uri . $block_name . '/' . $handle_file . '.js',
 				$args['dependencies'] ?? [],
 				$args['version'] ?? false,


### PR DESCRIPTION
## What does this do/fix?

Fixes #102.

`Assets_Enqueuer` suffixes the **style** handle with the block name but not the **script** handle, so every registered UCSC block enqueued its JS under the same handle (`index`). `wp_enqueue_script()` ignores repeat registrations of an existing handle, so only the first block in the registry ever got its script — editor-side JS for every block after it was silently missing.

The fix suffixes the script handle the same way the style handle already is:

```php
wp_enqueue_script(
    $handle_file . '-' . $block_name,   // was: $handle_file
```

Handles now come out as `index-news-block`, `index-magazine-block`, and so on. The `index.asset.php` version/dependency lookup and the `.js` URL are unchanged.

Also in here:

- Replaced the docblock note that described the bug (it pointed at this issue and said it was deliberately left alone for a docs-only PR).
- Marked roadmap item 12 done and bumped the resolved count 6 → 7.

## Tests

PHP-only change — no build required, since `Core::render_template()` reads PHP from `src/`. Nothing else in `src/` or `lib/` references the `index` handle (checked `wp_localize_script`, `wp_add_inline_script`, `wp_set_script_translations`, and dequeues), so nothing downstream needs updating.

1. `./vendor/bin/phpcs src/Assets/Assets_Enqueuer.php` — clean. Full `composer lint` still reports the 6 pre-existing nonce errors in `News_Blocks_Hooks.php` / `Taxonomies_Hooks.php` (roadmap items 5–6, #103), untouched here.
2. **Needs a manual check against a real install** — this was not verified in an editor, as there's no WordPress environment attached to the branch. On a news site, add two or more UCSC blocks to a page and confirm each one's editor JS runs. View source / check `wp_scripts()` and expect one `<script>` per block rather than a single `index`.
3. With `SCRIPT_DEBUG` on, confirm no duplicate-handle notices. Worth noting: the front-end and editor enqueuers both use basename `index`, so for a given block they now generate the same handle string — they point at the identical file, so the second `wp_enqueue_script()` is a harmless no-op, but that is the one thing most worth eyeballing in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
